### PR TITLE
Rename withdrawal and transfer event types to include the reason

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -66,8 +66,7 @@ func (Aggregate) RouteCommandToInstance(m dogma.Message) string {
 	}
 }
 
-// HandleCommand handles a command message that has been routed to this
-// handler.
+// HandleCommand handles a command message that has been routed to this handler.
 func (Aggregate) HandleCommand(s dogma.AggregateCommandScope, m dogma.Message) {
 	switch x := m.(type) {
 	case commands.OpenAccount:
@@ -123,7 +122,7 @@ func debitForWithdrawal(s dogma.AggregateCommandScope, m commands.DebitAccountFo
 			Amount:        m.Amount,
 		})
 	} else {
-		s.RecordEvent(events.WithdrawalDeclined{
+		s.RecordEvent(events.WithdrawalDeclinedDueToInsufficientFunds{
 			TransactionID: m.TransactionID,
 			AccountID:     m.AccountID,
 			Amount:        m.Amount,
@@ -141,7 +140,7 @@ func debitForTransfer(s dogma.AggregateCommandScope, m commands.DebitAccountForT
 			Amount:        m.Amount,
 		})
 	} else {
-		s.RecordEvent(events.TransferDeclined{
+		s.RecordEvent(events.TransferDeclinedDueToInsufficientFunds{
 			TransactionID: m.TransactionID,
 			AccountID:     m.AccountID,
 			Amount:        m.Amount,

--- a/messages/events/transfer.go
+++ b/messages/events/transfer.go
@@ -25,9 +25,9 @@ type AccountDebitedForTransfer struct {
 	Amount        int64
 }
 
-// TransferDeclined is an event that indicates a requested transfer has been
-// declined due to insufficient funds.
-type TransferDeclined struct {
+// TransferDeclinedDueToInsufficientFunds is an event that indicates a requested
+// transfer has been declined due to insufficient funds.
+type TransferDeclinedDueToInsufficientFunds struct {
 	TransactionID string
 	AccountID     string
 	Amount        int64

--- a/messages/events/withdrawal.go
+++ b/messages/events/withdrawal.go
@@ -16,9 +16,9 @@ type AccountDebitedForWithdrawal struct {
 	Amount        int64
 }
 
-// WithdrawalDeclined is an event that indicates a requested withdrawal has been
-// declined due to insufficient funds.
-type WithdrawalDeclined struct {
+// WithdrawalDeclinedDueToInsufficientFunds is an event that indicates a
+// requested withdrawal has been declined due to insufficient funds.
+type WithdrawalDeclinedDueToInsufficientFunds struct {
 	TransactionID string
 	AccountID     string
 	Amount        int64

--- a/transaction/transfer.go
+++ b/transaction/transfer.go
@@ -23,14 +23,13 @@ func (TransferProcess) New() dogma.ProcessRoot {
 	return &transfer{}
 }
 
-// Configure configures the behavior of the engine as it relates to this
-// handler.
+// Configure configures the behavior of the engine as it relates to this handler.
 func (TransferProcess) Configure(c dogma.ProcessConfigurer) {
 	c.Name("transfer")
 	c.RouteEventType(events.TransferStarted{})
 	c.RouteEventType(events.AccountDebitedForTransfer{})
 	c.RouteEventType(events.AccountCreditedForTransfer{})
-	c.RouteEventType(events.TransferDeclined{})
+	c.RouteEventType(events.TransferDeclinedDueToInsufficientFunds{})
 }
 
 // RouteEventToInstance returns the ID of the process instance that is targetted
@@ -43,7 +42,7 @@ func (TransferProcess) RouteEventToInstance(_ context.Context, m dogma.Message) 
 		return x.TransactionID, true, nil
 	case events.AccountCreditedForTransfer:
 		return x.TransactionID, true, nil
-	case events.TransferDeclined:
+	case events.TransferDeclinedDueToInsufficientFunds:
 		return x.TransactionID, true, nil
 	default:
 		panic(dogma.UnexpectedMessage)
@@ -78,7 +77,8 @@ func (TransferProcess) HandleEvent(
 			Amount:        x.Amount,
 		})
 
-	case events.AccountCreditedForTransfer, events.TransferDeclined:
+	case events.AccountCreditedForTransfer,
+		events.TransferDeclinedDueToInsufficientFunds:
 		s.End()
 
 	default:

--- a/transaction/transfer_test.go
+++ b/transaction/transfer_test.go
@@ -80,7 +80,7 @@ func TestTransferProcess_InsufficientFunds(t *testing.T) {
 			},
 			AllOf(
 				EventRecorded(
-					events.TransferDeclined{
+					events.TransferDeclinedDueToInsufficientFunds{
 						TransactionID: "T001",
 						AccountID:     "A001",
 						Amount:        1000,

--- a/transaction/withdrawal.go
+++ b/transaction/withdrawal.go
@@ -20,7 +20,7 @@ func (WithdrawalProcess) Configure(c dogma.ProcessConfigurer) {
 	c.Name("withdrawal")
 	c.RouteEventType(events.WithdrawalStarted{})
 	c.RouteEventType(events.AccountDebitedForWithdrawal{})
-	c.RouteEventType(events.WithdrawalDeclined{})
+	c.RouteEventType(events.WithdrawalDeclinedDueToInsufficientFunds{})
 }
 
 // RouteEventToInstance returns the ID of the process instance that is targetted
@@ -31,7 +31,7 @@ func (WithdrawalProcess) RouteEventToInstance(_ context.Context, m dogma.Message
 		return x.TransactionID, true, nil
 	case events.AccountDebitedForWithdrawal:
 		return x.TransactionID, true, nil
-	case events.WithdrawalDeclined:
+	case events.WithdrawalDeclinedDueToInsufficientFunds:
 		return x.TransactionID, true, nil
 	default:
 		return "", false, nil
@@ -53,7 +53,8 @@ func (WithdrawalProcess) HandleEvent(
 			Amount:        x.Amount,
 		})
 
-	case events.AccountDebitedForWithdrawal, events.WithdrawalDeclined:
+	case events.AccountDebitedForWithdrawal,
+		events.WithdrawalDeclinedDueToInsufficientFunds:
 		s.End()
 
 	default:


### PR DESCRIPTION
A future change to the example project will add another declined reason.