### PR TITLE
Implement customer acquire, account open and change email address

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -100,8 +100,9 @@ func openAccount(s dogma.AggregateCommandScope, m commands.OpenAccount) {
 	}
 
 	s.RecordEvent(events.AccountOpened{
-		AccountID: m.AccountID,
-		Name:      m.Name,
+		CustomerID:  m.CustomerID,
+		AccountID:   m.AccountID,
+		AccountName: m.AccountName,
 	})
 }
 

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -19,13 +19,13 @@ func TestAccount_OpenAccount(t *testing.T) {
 					commands.OpenAccount{
 						CustomerID:  "C001",
 						AccountID:   "A001",
-						AccountName: "Savings",
+						AccountName: "Anna Smith",
 					},
 					EventRecorded(
 						events.AccountOpened{
 							CustomerID:  "C001",
 							AccountID:   "A001",
-							AccountName: "Savings",
+							AccountName: "Anna Smith",
 						},
 					),
 				)
@@ -38,7 +38,7 @@ func TestAccount_OpenAccount(t *testing.T) {
 			cmd := commands.OpenAccount{
 				CustomerID:  "C001",
 				AccountID:   "A001",
-				AccountName: "Savings",
+				AccountName: "Anna Smith",
 			}
 
 			testrunner.Runner.

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -35,17 +35,21 @@ func TestAccount_OpenAccount(t *testing.T) {
 	t.Run(
 		"it does not open an account that is already open",
 		func(t *testing.T) {
-			cmd := commands.OpenAccount{
-				CustomerID:  "C001",
-				AccountID:   "A001",
-				AccountName: "Anna Smith",
-			}
 
 			testrunner.Runner.
 				Begin(t).
-				Prepare(cmd).
+				Prepare(
+					commands.OpenAccount{
+						CustomerID:  "C001",
+						AccountID:   "A001",
+						AccountName: "Anna Smith",
+					}).
 				ExecuteCommand(
-					cmd,
+					commands.OpenAccount{
+						CustomerID:  "C001",
+						AccountID:   "A001",
+						AccountName: "Anna Smith",
+					},
 					NoneOf(
 						EventTypeRecorded(events.AccountOpened{}),
 					),

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -17,13 +17,15 @@ func TestAccount_OpenAccount(t *testing.T) {
 				Begin(t).
 				ExecuteCommand(
 					commands.OpenAccount{
-						AccountID: "A001",
-						Name:      "Bob Jones",
+						CustomerID:  "C001",
+						AccountID:   "A001",
+						AccountName: "Savings",
 					},
 					EventRecorded(
 						events.AccountOpened{
-							AccountID: "A001",
-							Name:      "Bob Jones",
+							CustomerID:  "C001",
+							AccountID:   "A001",
+							AccountName: "Savings",
 						},
 					),
 				)
@@ -34,8 +36,9 @@ func TestAccount_OpenAccount(t *testing.T) {
 		"it does not open an account that is already open",
 		func(t *testing.T) {
 			cmd := commands.OpenAccount{
-				AccountID: "A001",
-				Name:      "Bob Jones",
+				CustomerID:  "C001",
+				AccountID:   "A001",
+				AccountName: "Savings",
 			}
 
 			testrunner.Runner.

--- a/app.go
+++ b/app.go
@@ -5,12 +5,15 @@ import (
 
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/example/account"
+	"github.com/dogmatiq/example/customer"
 	"github.com/dogmatiq/example/projections"
 	"github.com/dogmatiq/example/transaction"
 )
 
 // App is an implementation of dogma.Application for the bank example.
 type App struct {
+	customerAggregate    customer.Aggregate
+	acquireProcess       customer.AcquireProcess
 	accountAggregate     account.Aggregate
 	transactionAggregate transaction.Aggregate
 	depositProcess       transaction.DepositProcess
@@ -22,6 +25,8 @@ type App struct {
 // Configure configures the Dogma engine for this application.
 func (a *App) Configure(c dogma.ApplicationConfigurer) {
 	c.Name("bank")
+	c.RegisterAggregate(a.customerAggregate)
+	c.RegisterProcess(a.acquireProcess)
 	c.RegisterAggregate(a.accountAggregate)
 	c.RegisterAggregate(a.transactionAggregate)
 	c.RegisterProcess(a.depositProcess)

--- a/cmd/bank/main.go
+++ b/cmd/bank/main.go
@@ -23,13 +23,13 @@ func main() {
 			CustomerID:   "cust1",
 			CustomerName: "Anna Smith",
 			AccountID:    "acct1",
-			AccountName:  "Savings",
+			AccountName:  "Anna Smith",
 		},
 		commands.OpenAccountForNewCustomer{
 			CustomerID:   "cust2",
 			CustomerName: "Bob Jones",
 			AccountID:    "acct2",
-			AccountName:  "Savings",
+			AccountName:  "Bob Jones",
 		},
 		commands.Deposit{
 			TransactionID: "txn1",

--- a/cmd/bank/main.go
+++ b/cmd/bank/main.go
@@ -19,13 +19,17 @@ func main() {
 	}
 
 	messages := []dogma.Message{
-		commands.OpenAccount{
-			AccountID: "acct1",
-			Name:      "Anna Smith",
+		commands.OpenAccountForNewCustomer{
+			CustomerID:   "cust1",
+			CustomerName: "Anna Smith",
+			AccountID:    "acct1",
+			AccountName:  "Savings",
 		},
-		commands.OpenAccount{
-			AccountID: "acct2",
-			Name:      "Bob Jones",
+		commands.OpenAccountForNewCustomer{
+			CustomerID:   "cust2",
+			CustomerName: "Bob Jones",
+			AccountID:    "acct2",
+			AccountName:  "Savings",
 		},
 		commands.Deposit{
 			TransactionID: "txn1",

--- a/customer/acquire.go
+++ b/customer/acquire.go
@@ -1,0 +1,56 @@
+package customer
+
+import (
+	"context"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/example/messages/commands"
+	"github.com/dogmatiq/example/messages/events"
+)
+
+// AcquireProcess is manages the process of creating accounts for acquired
+// customers.
+type AcquireProcess struct {
+	dogma.StatelessProcessBehavior
+	dogma.NoTimeoutBehavior
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (AcquireProcess) Configure(c dogma.ProcessConfigurer) {
+	c.Name("acquire")
+
+	c.ConsumesEventType(events.CustomerAcquired{})
+
+	c.ProducesCommandType(commands.OpenAccount{})
+}
+
+// RouteEventToInstance returns the ID of the process instance that is targetted
+// by m.
+func (AcquireProcess) RouteEventToInstance(_ context.Context, m dogma.Message) (string, bool, error) {
+	switch x := m.(type) {
+	case events.CustomerAcquired:
+		return x.CustomerID, true, nil
+	default:
+		panic(dogma.UnexpectedMessage)
+	}
+}
+
+// HandleEvent handles an event message that has been routed to this handler.
+func (AcquireProcess) HandleEvent(_ context.Context, s dogma.ProcessEventScope, m dogma.Message) error {
+	switch x := m.(type) {
+	case events.CustomerAcquired:
+		s.Begin()
+		s.ExecuteCommand(commands.OpenAccount{
+			CustomerID:  x.CustomerID,
+			AccountID:   x.AccountID,
+			AccountName: x.AccountName,
+		})
+		s.End()
+
+	default:
+		panic(dogma.UnexpectedMessage)
+	}
+
+	return nil
+}

--- a/customer/acquire.go
+++ b/customer/acquire.go
@@ -8,7 +8,7 @@ import (
 	"github.com/dogmatiq/example/messages/events"
 )
 
-// AcquireProcess is manages the process of creating accounts for acquired
+// AcquireProcess manages the process of creating accounts for acquired
 // customers.
 type AcquireProcess struct {
 	dogma.StatelessProcessBehavior

--- a/customer/customer.go
+++ b/customer/customer.go
@@ -1,0 +1,93 @@
+package customer
+
+import (
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/example/messages/commands"
+	"github.com/dogmatiq/example/messages/events"
+)
+
+// customer is the aggregate root for a bank customer.
+type customer struct {
+	// Email is the customer email address.
+	Email string
+}
+
+func (c *customer) ApplyEvent(m dogma.Message) {
+	switch x := m.(type) {
+	case events.CustomerAcquired:
+		c.Email = x.CustomerEmail
+	case events.CustomerEmailAddressChanged:
+		c.Email = x.CustomerEmail
+	}
+}
+
+// Aggregate implements the business logic for a bank customer.
+type Aggregate struct{}
+
+// New returns a new customer instance.
+func (Aggregate) New() dogma.AggregateRoot {
+	return &customer{}
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (Aggregate) Configure(c dogma.AggregateConfigurer) {
+	c.Name("customer")
+
+	c.ConsumesCommandType(commands.OpenAccountForNewCustomer{})
+	c.ConsumesCommandType(commands.ChangeCustomerEmailAddress{})
+
+	c.ProducesEventType(events.CustomerAcquired{})
+	c.ProducesEventType(events.CustomerEmailAddressChanged{})
+}
+
+// RouteCommandToInstance returns the ID of the aggregate instance that is
+// targetted by m.
+func (Aggregate) RouteCommandToInstance(m dogma.Message) string {
+	switch x := m.(type) {
+	case commands.OpenAccountForNewCustomer:
+		return x.CustomerID
+	case commands.ChangeCustomerEmailAddress:
+		return x.CustomerID
+	default:
+		panic(dogma.UnexpectedMessage)
+	}
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (Aggregate) HandleCommand(s dogma.AggregateCommandScope, m dogma.Message) {
+	switch x := m.(type) {
+	case commands.OpenAccountForNewCustomer:
+		acquire(s, x)
+	case commands.ChangeCustomerEmailAddress:
+		changeEmailAddress(s, x)
+	default:
+		panic(dogma.UnexpectedMessage)
+	}
+}
+
+func acquire(s dogma.AggregateCommandScope, m commands.OpenAccountForNewCustomer) {
+	if !s.Create() {
+		s.Log("customer has already been acquired")
+		return
+	}
+
+	s.RecordEvent(events.CustomerAcquired{
+		CustomerID:    m.CustomerID,
+		CustomerName:  m.CustomerName,
+		CustomerEmail: m.CustomerEmail,
+		AccountID:     m.AccountID,
+		AccountName:   m.AccountName,
+	})
+}
+
+func changeEmailAddress(s dogma.AggregateCommandScope, m commands.ChangeCustomerEmailAddress) {
+	r := s.Root().(*customer)
+
+	if r.Email != m.CustomerEmail {
+		s.RecordEvent(events.CustomerEmailAddressChanged{
+			CustomerID:    m.CustomerID,
+			CustomerEmail: m.CustomerEmail,
+		})
+	}
+}

--- a/customer/customer_test.go
+++ b/customer/customer_test.go
@@ -37,7 +37,7 @@ func TestCustomer_OpenAccountForNewCustomer(t *testing.T) {
 	)
 
 	t.Run(
-		"it does not acquire a customer that already exists",
+		"it does not reacquire a customer that has already been acquired",
 		func(t *testing.T) {
 			cmd := commands.OpenAccountForNewCustomer{
 				CustomerID:    "C001",
@@ -91,7 +91,7 @@ func TestCustomer_ChangeCustomerEmailAddress(t *testing.T) {
 	)
 
 	t.Run(
-		"it does not change the email address if it is the same",
+		"it does not change the email address again if it has not changed",
 		func(t *testing.T) {
 			testrunner.Runner.
 				Begin(t).

--- a/customer/customer_test.go
+++ b/customer/customer_test.go
@@ -1,0 +1,118 @@
+package customer_test
+
+import (
+	"testing"
+
+	"github.com/dogmatiq/example/internal/testrunner"
+	"github.com/dogmatiq/example/messages/commands"
+	"github.com/dogmatiq/example/messages/events"
+	. "github.com/dogmatiq/testkit/assert"
+)
+
+func TestCustomer_OpenAccountForNewCustomer(t *testing.T) {
+	t.Run(
+		"it acquires the customer",
+		func(t *testing.T) {
+			testrunner.Runner.
+				Begin(t).
+				ExecuteCommand(
+					commands.OpenAccountForNewCustomer{
+						CustomerID:    "C001",
+						CustomerName:  "Bob Jones",
+						CustomerEmail: "email@1",
+						AccountID:     "A001",
+						AccountName:   "Savings",
+					},
+					EventRecorded(
+						events.CustomerAcquired{
+							CustomerID:    "C001",
+							CustomerName:  "Bob Jones",
+							CustomerEmail: "email@1",
+							AccountID:     "A001",
+							AccountName:   "Savings",
+						},
+					),
+				)
+		},
+	)
+
+	t.Run(
+		"it does not acquire a customer that already exists",
+		func(t *testing.T) {
+			cmd := commands.OpenAccountForNewCustomer{
+				CustomerID:    "C001",
+				CustomerName:  "Bob Jones",
+				CustomerEmail: "email@1",
+				AccountID:     "A001",
+				AccountName:   "Savings",
+			}
+
+			testrunner.Runner.
+				Begin(t).
+				Prepare(cmd).
+				ExecuteCommand(
+					cmd,
+					NoneOf(
+						EventTypeRecorded(events.CustomerAcquired{}),
+					),
+				)
+		},
+	)
+}
+
+func TestCustomer_ChangeCustomerEmailAddress(t *testing.T) {
+	t.Run(
+		"it changes the email address of the customer",
+		func(t *testing.T) {
+			testrunner.Runner.
+				Begin(t).
+				Prepare(
+					commands.OpenAccountForNewCustomer{
+						CustomerID:    "C001",
+						CustomerName:  "Bob Jones",
+						CustomerEmail: "email@1",
+						AccountID:     "A001",
+						AccountName:   "Savings",
+					},
+				).
+				ExecuteCommand(
+					commands.ChangeCustomerEmailAddress{
+						CustomerID:    "C001",
+						CustomerEmail: "email@1new",
+					},
+					EventRecorded(
+						events.CustomerEmailAddressChanged{
+							CustomerID:    "C001",
+							CustomerEmail: "email@1new",
+						},
+					),
+				)
+		},
+	)
+
+	t.Run(
+		"it does not change the email address if it is the same",
+		func(t *testing.T) {
+			testrunner.Runner.
+				Begin(t).
+				Prepare(
+					commands.OpenAccountForNewCustomer{
+						CustomerID:    "C001",
+						CustomerName:  "Bob Jones",
+						CustomerEmail: "email@1",
+						AccountID:     "A001",
+						AccountName:   "Savings",
+					},
+				).
+				ExecuteCommand(
+					commands.ChangeCustomerEmailAddress{
+						CustomerID:    "C001",
+						CustomerEmail: "email@1",
+					},
+					NoneOf(
+						EventTypeRecorded(events.CustomerEmailAddressChanged{}),
+					),
+				)
+		},
+	)
+}

--- a/customer/customer_test.go
+++ b/customer/customer_test.go
@@ -19,7 +19,7 @@ func TestCustomer_OpenAccountForNewCustomer(t *testing.T) {
 					commands.OpenAccountForNewCustomer{
 						CustomerID:    "C001",
 						CustomerName:  "Bob Jones",
-						CustomerEmail: "email@1",
+						CustomerEmail: "bob@example.com",
 						AccountID:     "A001",
 						AccountName:   "Savings",
 					},
@@ -27,7 +27,7 @@ func TestCustomer_OpenAccountForNewCustomer(t *testing.T) {
 						events.CustomerAcquired{
 							CustomerID:    "C001",
 							CustomerName:  "Bob Jones",
-							CustomerEmail: "email@1",
+							CustomerEmail: "bob@example.com",
 							AccountID:     "A001",
 							AccountName:   "Savings",
 						},
@@ -42,7 +42,7 @@ func TestCustomer_OpenAccountForNewCustomer(t *testing.T) {
 			cmd := commands.OpenAccountForNewCustomer{
 				CustomerID:    "C001",
 				CustomerName:  "Bob Jones",
-				CustomerEmail: "email@1",
+				CustomerEmail: "bob@example.com",
 				AccountID:     "A001",
 				AccountName:   "Savings",
 			}
@@ -70,7 +70,7 @@ func TestCustomer_ChangeCustomerEmailAddress(t *testing.T) {
 					commands.OpenAccountForNewCustomer{
 						CustomerID:    "C001",
 						CustomerName:  "Bob Jones",
-						CustomerEmail: "email@1",
+						CustomerEmail: "bob@example.com",
 						AccountID:     "A001",
 						AccountName:   "Savings",
 					},
@@ -78,12 +78,12 @@ func TestCustomer_ChangeCustomerEmailAddress(t *testing.T) {
 				ExecuteCommand(
 					commands.ChangeCustomerEmailAddress{
 						CustomerID:    "C001",
-						CustomerEmail: "email@1new",
+						CustomerEmail: "newbob@example.com",
 					},
 					EventRecorded(
 						events.CustomerEmailAddressChanged{
 							CustomerID:    "C001",
-							CustomerEmail: "email@1new",
+							CustomerEmail: "newbob@example.com",
 						},
 					),
 				)
@@ -99,7 +99,7 @@ func TestCustomer_ChangeCustomerEmailAddress(t *testing.T) {
 					commands.OpenAccountForNewCustomer{
 						CustomerID:    "C001",
 						CustomerName:  "Bob Jones",
-						CustomerEmail: "email@1",
+						CustomerEmail: "bob@example.com",
 						AccountID:     "A001",
 						AccountName:   "Savings",
 					},
@@ -107,7 +107,7 @@ func TestCustomer_ChangeCustomerEmailAddress(t *testing.T) {
 				ExecuteCommand(
 					commands.ChangeCustomerEmailAddress{
 						CustomerID:    "C001",
-						CustomerEmail: "email@1",
+						CustomerEmail: "bob@example.com",
 					},
 					NoneOf(
 						EventTypeRecorded(events.CustomerEmailAddressChanged{}),

--- a/customer/customer_test.go
+++ b/customer/customer_test.go
@@ -21,7 +21,7 @@ func TestCustomer_OpenAccountForNewCustomer(t *testing.T) {
 						CustomerName:  "Bob Jones",
 						CustomerEmail: "bob@example.com",
 						AccountID:     "A001",
-						AccountName:   "Savings",
+						AccountName:   "Bob Jones",
 					},
 					EventRecorded(
 						events.CustomerAcquired{
@@ -29,7 +29,7 @@ func TestCustomer_OpenAccountForNewCustomer(t *testing.T) {
 							CustomerName:  "Bob Jones",
 							CustomerEmail: "bob@example.com",
 							AccountID:     "A001",
-							AccountName:   "Savings",
+							AccountName:   "Bob Jones",
 						},
 					),
 				)
@@ -44,7 +44,7 @@ func TestCustomer_OpenAccountForNewCustomer(t *testing.T) {
 				CustomerName:  "Bob Jones",
 				CustomerEmail: "bob@example.com",
 				AccountID:     "A001",
-				AccountName:   "Savings",
+				AccountName:   "Bob Jones",
 			}
 
 			testrunner.Runner.
@@ -72,7 +72,7 @@ func TestCustomer_ChangeCustomerEmailAddress(t *testing.T) {
 						CustomerName:  "Bob Jones",
 						CustomerEmail: "bob@example.com",
 						AccountID:     "A001",
-						AccountName:   "Savings",
+						AccountName:   "Bob Jones",
 					},
 				).
 				ExecuteCommand(
@@ -101,7 +101,7 @@ func TestCustomer_ChangeCustomerEmailAddress(t *testing.T) {
 						CustomerName:  "Bob Jones",
 						CustomerEmail: "bob@example.com",
 						AccountID:     "A001",
-						AccountName:   "Savings",
+						AccountName:   "Bob Jones",
 					},
 				).
 				ExecuteCommand(

--- a/customer/doc.go
+++ b/customer/doc.go
@@ -1,0 +1,2 @@
+// Package customer contains the business logic for bank customers.
+package customer

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dogmatiq/example
 go 1.12
 
 require (
+	github.com/dogmatiq/dapper v0.3.2
 	github.com/dogmatiq/dogma v0.4.0
 	github.com/dogmatiq/graphkit v0.0.0-20190303221255-3d350c82d54e
 	github.com/dogmatiq/testkit v0.0.0-20190417003242-a42b8582cc6b

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/dogmatiq/example
 go 1.12
 
 require (
-	github.com/dogmatiq/dapper v0.3.2
 	github.com/dogmatiq/dogma v0.4.0
 	github.com/dogmatiq/graphkit v0.0.0-20190303221255-3d350c82d54e
 	github.com/dogmatiq/testkit v0.0.0-20190417003242-a42b8582cc6b

--- a/messages/commands/account.go
+++ b/messages/commands/account.go
@@ -1,7 +1,9 @@
 package commands
 
-// OpenAccount is a command requesting that a new bank account be opened.
+// OpenAccount is a command requesting that a new bank account be opened for an
+// existing customer.
 type OpenAccount struct {
-	AccountID string
-	Name      string
+	CustomerID  string
+	AccountID   string
+	AccountName string
 }

--- a/messages/commands/account.go
+++ b/messages/commands/account.go
@@ -1,5 +1,15 @@
 package commands
 
+// OpenAccountForNewCustomer is a command requesting that a new bank account be
+// opened for a new customer.
+type OpenAccountForNewCustomer struct {
+	CustomerID    string
+	CustomerName  string
+	CustomerEmail string
+	AccountID     string
+	AccountName   string
+}
+
 // OpenAccount is a command requesting that a new bank account be opened for an
 // existing customer.
 type OpenAccount struct {

--- a/messages/commands/customer.go
+++ b/messages/commands/customer.go
@@ -1,15 +1,5 @@
 package commands
 
-// OpenAccountForNewCustomer is a command requesting that a new bank account be
-// opened for a new customer.
-type OpenAccountForNewCustomer struct {
-	CustomerID    string
-	CustomerName  string
-	CustomerEmail string
-	AccountID     string
-	AccountName   string
-}
-
 type ChangeCustomerEmailAddress struct {
 	CustomerID    string
 	CustomerEmail string

--- a/messages/commands/customer.go
+++ b/messages/commands/customer.go
@@ -1,5 +1,7 @@
 package commands
 
+// ChangeCustomerEmailAddress is a command requesting that a customer email
+// address be changed.
 type ChangeCustomerEmailAddress struct {
 	CustomerID    string
 	CustomerEmail string

--- a/messages/commands/customer.go
+++ b/messages/commands/customer.go
@@ -1,0 +1,16 @@
+package commands
+
+// OpenAccountForNewCustomer is a command requesting that a new bank account be
+// opened for a new customer.
+type OpenAccountForNewCustomer struct {
+	CustomerID    string
+	CustomerName  string
+	CustomerEmail string
+	AccountID     string
+	AccountName   string
+}
+
+type ChangeCustomerEmailAddress struct {
+	CustomerID    string
+	CustomerEmail string
+}

--- a/messages/events/account.go
+++ b/messages/events/account.go
@@ -2,6 +2,7 @@ package events
 
 // AccountOpened is an event indicating that a new bank account has been opened.
 type AccountOpened struct {
-	AccountID string
-	Name      string
+	CustomerID  string
+	AccountID   string
+	AccountName string
 }

--- a/messages/events/customer.go
+++ b/messages/events/customer.go
@@ -1,0 +1,18 @@
+package events
+
+// CustomerAcquired is an event indicating that a new customer has been
+// acquired.
+type CustomerAcquired struct {
+	CustomerID    string
+	CustomerName  string
+	CustomerEmail string
+	AccountID     string
+	AccountName   string
+}
+
+// CustomerEmailAddressChanged is an event indicating that a customer has
+// changed their email address.
+type CustomerEmailAddressChanged struct {
+	CustomerID    string
+	CustomerEmail string
+}

--- a/projections/account.go
+++ b/projections/account.go
@@ -108,7 +108,7 @@ func (h *AccountProjectionHandler) HandleEvent(
 	switch x := m.(type) {
 	case events.AccountOpened:
 		r := h.get(x.AccountID)
-		r.Name = x.Name
+		r.Name = x.AccountName
 
 	case events.AccountCreditedForDeposit:
 		r := h.get(x.AccountID)

--- a/transaction/transfer_test.go
+++ b/transaction/transfer_test.go
@@ -14,12 +14,14 @@ func TestTransferProcess_SufficientFunds(t *testing.T) {
 		Begin(t).
 		Prepare(
 			commands.OpenAccount{
-				AccountID: "A001",
-				Name:      "Anna",
+				CustomerID:  "C001",
+				AccountID:   "A001",
+				AccountName: "Savings",
 			},
 			commands.OpenAccount{
-				AccountID: "A002",
-				Name:      "Bob",
+				CustomerID:  "C002",
+				AccountID:   "A002",
+				AccountName: "Savings",
 			},
 			commands.Deposit{
 				TransactionID: "D001",
@@ -58,12 +60,14 @@ func TestTransferProcess_InsufficientFunds(t *testing.T) {
 		Begin(t).
 		Prepare(
 			commands.OpenAccount{
-				AccountID: "A001",
-				Name:      "Anna",
+				CustomerID:  "C001",
+				AccountID:   "A001",
+				AccountName: "Savings",
 			},
 			commands.OpenAccount{
-				AccountID: "A002",
-				Name:      "Bob",
+				CustomerID:  "C002",
+				AccountID:   "A002",
+				AccountName: "Savings",
 			},
 			commands.Deposit{
 				TransactionID: "D001",

--- a/transaction/transfer_test.go
+++ b/transaction/transfer_test.go
@@ -16,12 +16,12 @@ func TestTransferProcess_SufficientFunds(t *testing.T) {
 			commands.OpenAccount{
 				CustomerID:  "C001",
 				AccountID:   "A001",
-				AccountName: "Savings",
+				AccountName: "Anna Smith",
 			},
 			commands.OpenAccount{
 				CustomerID:  "C002",
 				AccountID:   "A002",
-				AccountName: "Savings",
+				AccountName: "Bob Jones",
 			},
 			commands.Deposit{
 				TransactionID: "D001",
@@ -62,12 +62,12 @@ func TestTransferProcess_InsufficientFunds(t *testing.T) {
 			commands.OpenAccount{
 				CustomerID:  "C001",
 				AccountID:   "A001",
-				AccountName: "Savings",
+				AccountName: "Anna Smith",
 			},
 			commands.OpenAccount{
 				CustomerID:  "C002",
 				AccountID:   "A002",
-				AccountName: "Savings",
+				AccountName: "Bob Jones",
 			},
 			commands.Deposit{
 				TransactionID: "D001",


### PR DESCRIPTION
This PR implements features we designed in the tactical DDD session. It is essentially a refactor of the basic account feature. The existing transaction features have only had minor changes where requried.

* When an account is opened for a new customer, the customer is acquired.
* A customer can open more accounts.
* A customer can change email address.

I'm not sure if the `OpenAccountForNewCustomer` command should go in the `commands/customer.go` or `commands/account.go`?