### PR TITLE
Rename and move acquire process from customer to account

### DIFF
--- a/account/openAccount.go
+++ b/account/openAccount.go
@@ -1,4 +1,4 @@
-package customer
+package account
 
 import (
 	"context"
@@ -8,17 +8,17 @@ import (
 	"github.com/dogmatiq/example/messages/events"
 )
 
-// AcquireProcess manages the process of creating accounts for acquired
-// customers.
-type AcquireProcess struct {
+// OpenAccountForNewCustomerProcess manages the process of opening the initial
+// account for a new customer.
+type OpenAccountForNewCustomerProcess struct {
 	dogma.StatelessProcessBehavior
 	dogma.NoTimeoutBehavior
 }
 
 // Configure configures the behavior of the engine as it relates to this
 // handler.
-func (AcquireProcess) Configure(c dogma.ProcessConfigurer) {
-	c.Name("acquire")
+func (OpenAccountForNewCustomerProcess) Configure(c dogma.ProcessConfigurer) {
+	c.Name("open-account-for-new-customer")
 
 	c.ConsumesEventType(events.CustomerAcquired{})
 
@@ -27,7 +27,7 @@ func (AcquireProcess) Configure(c dogma.ProcessConfigurer) {
 
 // RouteEventToInstance returns the ID of the process instance that is targetted
 // by m.
-func (AcquireProcess) RouteEventToInstance(_ context.Context, m dogma.Message) (string, bool, error) {
+func (OpenAccountForNewCustomerProcess) RouteEventToInstance(_ context.Context, m dogma.Message) (string, bool, error) {
 	switch x := m.(type) {
 	case events.CustomerAcquired:
 		return x.CustomerID, true, nil
@@ -37,7 +37,7 @@ func (AcquireProcess) RouteEventToInstance(_ context.Context, m dogma.Message) (
 }
 
 // HandleEvent handles an event message that has been routed to this handler.
-func (AcquireProcess) HandleEvent(_ context.Context, s dogma.ProcessEventScope, m dogma.Message) error {
+func (OpenAccountForNewCustomerProcess) HandleEvent(_ context.Context, s dogma.ProcessEventScope, m dogma.Message) error {
 	switch x := m.(type) {
 	case events.CustomerAcquired:
 		s.Begin()

--- a/app.go
+++ b/app.go
@@ -12,21 +12,21 @@ import (
 
 // App is an implementation of dogma.Application for the bank example.
 type App struct {
-	customerAggregate    customer.Aggregate
-	acquireProcess       customer.AcquireProcess
-	accountAggregate     account.Aggregate
-	transactionAggregate transaction.Aggregate
-	depositProcess       transaction.DepositProcess
-	withdrawalProcess    transaction.WithdrawalProcess
-	transferProcess      transaction.TransferProcess
-	accountProjection    projections.AccountProjectionHandler
+	customerAggregate                customer.Aggregate
+	accountAggregate                 account.Aggregate
+	openAccountForNewCustomerProcess account.OpenAccountForNewCustomerProcess
+	transactionAggregate             transaction.Aggregate
+	depositProcess                   transaction.DepositProcess
+	withdrawalProcess                transaction.WithdrawalProcess
+	transferProcess                  transaction.TransferProcess
+	accountProjection                projections.AccountProjectionHandler
 }
 
 // Configure configures the Dogma engine for this application.
 func (a *App) Configure(c dogma.ApplicationConfigurer) {
 	c.Name("bank")
 	c.RegisterAggregate(a.customerAggregate)
-	c.RegisterProcess(a.acquireProcess)
+	c.RegisterProcess(a.openAccountForNewCustomerProcess)
 	c.RegisterAggregate(a.accountAggregate)
 	c.RegisterAggregate(a.transactionAggregate)
 	c.RegisterProcess(a.depositProcess)


### PR DESCRIPTION
As dicsussed, this moves the `acquire.go` process file from `customer` to `account` and renames `AcquireProcess` to `OpenAccountForNewCustomerProcess`.

This also now makes the graph match the DDD tactical design.
