### PR TITLE
Remove customer email address feature

### DIFF
--- a/domain/customer_test.go
+++ b/domain/customer_test.go
@@ -20,19 +20,17 @@ func Test_OpenAccountForNewCustomer(t *testing.T) {
 						Begin(t).
 						ExecuteCommand(
 							commands.OpenAccountForNewCustomer{
-								CustomerID:    "C001",
-								CustomerName:  "Bob Jones",
-								CustomerEmail: "bob@example.com",
-								AccountID:     "A001",
-								AccountName:   "Bob Jones",
+								CustomerID:   "C001",
+								CustomerName: "Bob Jones",
+								AccountID:    "A001",
+								AccountName:  "Bob Jones",
 							},
 							EventRecorded(
 								events.CustomerAcquired{
-									CustomerID:    "C001",
-									CustomerName:  "Bob Jones",
-									CustomerEmail: "bob@example.com",
-									AccountID:     "A001",
-									AccountName:   "Bob Jones",
+									CustomerID:   "C001",
+									CustomerName: "Bob Jones",
+									AccountID:    "A001",
+									AccountName:  "Bob Jones",
 								},
 							),
 						)
@@ -48,11 +46,10 @@ func Test_OpenAccountForNewCustomer(t *testing.T) {
 				"it does not reacquire the customer",
 				func(t *testing.T) {
 					cmd := commands.OpenAccountForNewCustomer{
-						CustomerID:    "C001",
-						CustomerName:  "Bob Jones",
-						CustomerEmail: "bob@example.com",
-						AccountID:     "A001",
-						AccountName:   "Bob Jones",
+						CustomerID:   "C001",
+						CustomerName: "Bob Jones",
+						AccountID:    "A001",
+						AccountName:  "Bob Jones",
 					}
 
 					testrunner.Runner.
@@ -62,73 +59,6 @@ func Test_OpenAccountForNewCustomer(t *testing.T) {
 							cmd,
 							NoneOf(
 								EventTypeRecorded(events.CustomerAcquired{}),
-							),
-						)
-				},
-			)
-		},
-	)
-}
-
-func Test_ChangeCustomerEmailAddress(t *testing.T) {
-	t.Run(
-		"when the email address is different",
-		func(t *testing.T) {
-			t.Run(
-				"it changes the email address of the customer",
-				func(t *testing.T) {
-					testrunner.Runner.
-						Begin(t).
-						Prepare(
-							commands.OpenAccountForNewCustomer{
-								CustomerID:    "C001",
-								CustomerName:  "Bob Jones",
-								CustomerEmail: "bob@example.com",
-								AccountID:     "A001",
-								AccountName:   "Bob Jones",
-							},
-						).
-						ExecuteCommand(
-							commands.ChangeCustomerEmailAddress{
-								CustomerID:    "C001",
-								CustomerEmail: "newbob@example.com",
-							},
-							EventRecorded(
-								events.CustomerEmailAddressChanged{
-									CustomerID:    "C001",
-									CustomerEmail: "newbob@example.com",
-								},
-							),
-						)
-				},
-			)
-		},
-	)
-
-	t.Run(
-		"when the email address is the same",
-		func(t *testing.T) {
-			t.Run(
-				"it does not change the email address",
-				func(t *testing.T) {
-					testrunner.Runner.
-						Begin(t).
-						Prepare(
-							commands.OpenAccountForNewCustomer{
-								CustomerID:    "C001",
-								CustomerName:  "Bob Jones",
-								CustomerEmail: "bob@example.com",
-								AccountID:     "A001",
-								AccountName:   "Bob Jones",
-							},
-						).
-						ExecuteCommand(
-							commands.ChangeCustomerEmailAddress{
-								CustomerID:    "C001",
-								CustomerEmail: "bob@example.com",
-							},
-							NoneOf(
-								EventTypeRecorded(events.CustomerEmailAddressChanged{}),
 							),
 						)
 				},

--- a/messages/commands/account.go
+++ b/messages/commands/account.go
@@ -5,11 +5,10 @@ import "github.com/dogmatiq/example/messages"
 // OpenAccountForNewCustomer is a command requesting that a new bank account be
 // opened for a new customer.
 type OpenAccountForNewCustomer struct {
-	CustomerID    string
-	CustomerName  string
-	CustomerEmail string
-	AccountID     string
-	AccountName   string
+	CustomerID   string
+	CustomerName string
+	AccountID    string
+	AccountName  string
 }
 
 // OpenAccount is a command requesting that a new bank account be opened for an

--- a/messages/commands/customer.go
+++ b/messages/commands/customer.go
@@ -1,8 +1,0 @@
-package commands
-
-// ChangeCustomerEmailAddress is a command requesting that a customer email
-// address be changed.
-type ChangeCustomerEmailAddress struct {
-	CustomerID    string
-	CustomerEmail string
-}

--- a/messages/events/customer.go
+++ b/messages/events/customer.go
@@ -3,16 +3,8 @@ package events
 // CustomerAcquired is an event indicating that a new customer has been
 // acquired.
 type CustomerAcquired struct {
-	CustomerID    string
-	CustomerName  string
-	CustomerEmail string
-	AccountID     string
-	AccountName   string
-}
-
-// CustomerEmailAddressChanged is an event indicating that a customer has
-// changed their email address.
-type CustomerEmailAddressChanged struct {
-	CustomerID    string
-	CustomerEmail string
+	CustomerID   string
+	CustomerName string
+	AccountID    string
+	AccountName  string
 }


### PR DESCRIPTION
This feature is not needed for the example. By removing it we will keep things focused.

Fixes #30