### PR TITLE
Allow `nil` db when creating app for tests and remove `testkit.Runner`

### DIFF
--- a/app.go
+++ b/app.go
@@ -29,7 +29,7 @@ type App struct {
 
 // NewApp returns the example application.
 //
-// db may be nil to bypass projection database setup.
+// If db is nil, it omits projection message handlers from the configuration.
 func NewApp(db *sql.DB) (*App, error) {
 	app := &App{}
 

--- a/app.go
+++ b/app.go
@@ -28,19 +28,25 @@ type App struct {
 }
 
 // NewApp returns the example application.
+//
+// db may be nil to bypass projection database setup.
 func NewApp(db *sql.DB) (*App, error) {
-	cust, err := pksql.New(
-		db,
-		&projections.CustomerProjectionHandler{},
-		nil,
-	)
-	if err != nil {
-		return nil, err
+	app := &App{}
+
+	if db != nil {
+		cust, err := pksql.New(
+			db,
+			&projections.CustomerProjectionHandler{},
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		app.CustomerProjection = cust
 	}
 
-	return &App{
-		CustomerProjection: cust,
-	}, nil
+	return app, nil
 }
 
 // Configure configures the Dogma engine for this application.

--- a/cmd/bank/main.go
+++ b/cmd/bank/main.go
@@ -5,13 +5,13 @@ import (
 	"os"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/example"
 	"github.com/dogmatiq/example/internal/database"
 	"github.com/dogmatiq/example/messages"
 	"github.com/dogmatiq/example/messages/commands"
 	"github.com/dogmatiq/testkit/engine"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func businessDayFromTime(t time.Time) string {

--- a/domain/account_test.go
+++ b/domain/account_test.go
@@ -16,7 +16,7 @@ func Test_OpenAccount(t *testing.T) {
 			t.Run(
 				"the new account is opened",
 				func(t *testing.T) {
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(t).
 						ExecuteCommand(
 							commands.OpenAccount{
@@ -43,7 +43,7 @@ func Test_OpenAccount(t *testing.T) {
 			t.Run(
 				"nothing happens to the existing account",
 				func(t *testing.T) {
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(t).
 						Prepare(
 							commands.OpenAccount{

--- a/domain/customer_test.go
+++ b/domain/customer_test.go
@@ -16,7 +16,7 @@ func Test_OpenAccountForNewCustomer(t *testing.T) {
 			t.Run(
 				"it acquires the customer",
 				func(t *testing.T) {
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(t).
 						ExecuteCommand(
 							commands.OpenAccountForNewCustomer{
@@ -52,7 +52,7 @@ func Test_OpenAccountForNewCustomer(t *testing.T) {
 						AccountName:  "Bob Jones",
 					}
 
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(t).
 						Prepare(cmd).
 						ExecuteCommand(

--- a/domain/deposit_test.go
+++ b/domain/deposit_test.go
@@ -13,7 +13,7 @@ func Test_Deposit(t *testing.T) {
 	t.Run(
 		"it deposits the funds into the account",
 		func(t *testing.T) {
-			testrunner.Runner.
+			testrunner.New(nil).
 				Begin(t).
 				Prepare(
 					commands.OpenAccount{

--- a/domain/transfer_test.go
+++ b/domain/transfer_test.go
@@ -19,7 +19,7 @@ func Test_Transfer(t *testing.T) {
 			t.Run(
 				"it transfers the funds from one account to another",
 				func(t *testing.T) {
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(t).
 						Prepare(
 							commands.OpenAccount{
@@ -82,7 +82,7 @@ func Test_Transfer(t *testing.T) {
 			t.Run(
 				"it does not transfer any funds from the account",
 				func(t *testing.T) {
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(t).
 						Prepare(
 							commands.OpenAccount{
@@ -146,7 +146,7 @@ func Test_Transfer(t *testing.T) {
 			t.Run(
 				"it transfers the funds from one account to another",
 				func(t *testing.T) {
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(t).
 						Prepare(
 							commands.OpenAccount{
@@ -209,7 +209,7 @@ func Test_Transfer(t *testing.T) {
 			t.Run(
 				"it does not transfer any funds from the account",
 				func(t *testing.T) {
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(t).
 						Prepare(
 							commands.OpenAccount{
@@ -274,7 +274,7 @@ func Test_Transfer(t *testing.T) {
 			t.Run(
 				"it transfers the funds after the scheduled time",
 				func(t *testing.T) {
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(
 							t,
 							WithStartTime(

--- a/domain/withdrawal_test.go
+++ b/domain/withdrawal_test.go
@@ -17,7 +17,7 @@ func Test_Withdraw(t *testing.T) {
 			t.Run(
 				"it withdraws the funds from the account",
 				func(t *testing.T) {
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(t).
 						Prepare(
 							commands.OpenAccount{
@@ -57,7 +57,7 @@ func Test_Withdraw(t *testing.T) {
 			t.Run(
 				"it does not withdraw funds from the account",
 				func(t *testing.T) {
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(t).
 						Prepare(
 							commands.OpenAccount{
@@ -93,7 +93,7 @@ func Test_Withdraw(t *testing.T) {
 			t.Run(
 				"it withdraws the funds from the account",
 				func(t *testing.T) {
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(t).
 						Prepare(
 							commands.OpenAccount{
@@ -128,7 +128,7 @@ func Test_Withdraw(t *testing.T) {
 			t.Run(
 				"it enforces the daily debit limit per account",
 				func(t *testing.T) {
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(t).
 						Prepare(
 							commands.OpenAccount{
@@ -188,7 +188,7 @@ func Test_Withdraw(t *testing.T) {
 			t.Run(
 				"it enforces the daily debit limit per day",
 				func(t *testing.T) {
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(t).
 						Prepare(
 							commands.OpenAccount{
@@ -234,7 +234,7 @@ func Test_Withdraw(t *testing.T) {
 			t.Run(
 				"it does not withdraw any funds from the account",
 				func(t *testing.T) {
-					testrunner.Runner.
+					testrunner.New(nil).
 						Begin(t).
 						Prepare(
 							commands.OpenAccount{

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -7,9 +7,6 @@ import (
 	"github.com/dogmatiq/testkit"
 )
 
-// Runner is a test runner for the example application, without projections.
-var Runner = testkit.New(&example.App{})
-
 // New returns a test runner for the example application.
 func New(db *sql.DB) *testkit.Runner {
 	app, err := example.NewApp(db)


### PR DESCRIPTION
`NewApp()` in `app.go` will be updated to allow a `nil` database to bypass setting up projections for tests that do no need a database.

The `Runner` variable will be removed from `testrunner.go` and tests will be updated to create a new app with either a fresh database or a `nil` database each time they run.

Fixes #36