### PR TITLE
Add `database.CreateSchema()` and `DropSchema()`.

### DIFF
--- a/cmd/bank/main.go
+++ b/cmd/bank/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/example"
-	"github.com/dogmatiq/example/internal/database"
+	"github.com/dogmatiq/example/database"
 	"github.com/dogmatiq/example/messages"
 	"github.com/dogmatiq/example/messages/commands"
 	"github.com/dogmatiq/testkit/engine"
@@ -18,7 +18,7 @@ func businessDayFromTime(t time.Time) string {
 }
 
 func main() {
-	db := database.New()
+	db := database.MustNew()
 	defer db.Close()
 
 	app, err := example.NewApp(db)

--- a/database/doc.go
+++ b/database/doc.go
@@ -1,0 +1,3 @@
+// Package database provides functions for initializating the SQLite database
+// used to store projection data.
+package database

--- a/database/schema.go
+++ b/database/schema.go
@@ -1,0 +1,42 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+)
+
+// CreateSchema creates the schema elements required by the projection handlers.
+func CreateSchema(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(
+		ctx,
+		`CREATE TABLE customer (
+			id   TEXT NOT NULL,
+			name TEXT NOT NULL,
+
+			PRIMARY KEY (id)
+		);
+
+		CREATE TABLE account (
+			id          TEXT NOT NULL,
+			name        TEXT NOT NULL,
+			customer_id TEXT NOT NULL,
+			balance     INTEGER NOT NULL DEFAULT 0,
+
+			PRIMARY KEY (id)
+		);
+
+		CREATE INDEX idx_account_customer ON account (customer_id);
+		`,
+	)
+	return err
+}
+
+// DropSchema drops the schema elements required by the projection handlers.
+func DropSchema(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(
+		ctx,
+		`DROP TABLE IF EXISTS customer;
+		DROP TABLE IF EXISTS account;`,
+	)
+	return err
+}

--- a/projections/account_test.go
+++ b/projections/account_test.go
@@ -3,7 +3,7 @@ package projections_test
 import (
 	"testing"
 
-	"github.com/dogmatiq/example/internal/database"
+	"github.com/dogmatiq/example/database"
 	"github.com/dogmatiq/example/internal/testrunner"
 	"github.com/dogmatiq/example/messages"
 	"github.com/dogmatiq/example/messages/events"
@@ -15,7 +15,7 @@ func Test_AccountProjectionHandler(t *testing.T) {
 	t.Run(
 		"when an account is opened",
 		func(t *testing.T) {
-			db := database.New()
+			db := database.MustNew()
 			defer db.Close()
 
 			testrunner.New(db).
@@ -106,7 +106,7 @@ func Test_AccountProjectionHandler(t *testing.T) {
 	t.Run(
 		"when an account is credited",
 		func(t *testing.T) {
-			db := database.New()
+			db := database.MustNew()
 			defer db.Close()
 
 			testrunner.New(db).
@@ -177,7 +177,7 @@ func Test_AccountProjectionHandler(t *testing.T) {
 	t.Run(
 		"when an account is debited",
 		func(t *testing.T) {
-			db := database.New()
+			db := database.MustNew()
 			defer db.Close()
 
 			testrunner.New(db).

--- a/projections/customer_test.go
+++ b/projections/customer_test.go
@@ -3,7 +3,7 @@ package projections_test
 import (
 	"testing"
 
-	"github.com/dogmatiq/example/internal/database"
+	"github.com/dogmatiq/example/database"
 	"github.com/dogmatiq/example/internal/testrunner"
 	"github.com/dogmatiq/example/messages/commands"
 	"github.com/dogmatiq/testkit"
@@ -14,7 +14,7 @@ func Test_CustomerProjectionHandler(t *testing.T) {
 	t.Run(
 		"when an account is opened for a new customer",
 		func(t *testing.T) {
-			db := database.New()
+			db := database.MustNew()
 			defer db.Close()
 
 			testrunner.New(db).


### PR DESCRIPTION
This change involves exposing the previously internal `database` package.

To make for a better public-facing API, the `New()` method has been changed to return an error instead of panicking.

A `MustNew()` function has been added to retain the previous behavior of `New()`.