### PR TITLE
Use OO style aggregate methods

### DIFF
--- a/domain/deposit_test.go
+++ b/domain/deposit_test.go
@@ -11,46 +11,77 @@ import (
 
 func Test_Deposit(t *testing.T) {
 	t.Run(
-		"it deposits the funds into the account",
+		"when the deposit has not yet started",
 		func(t *testing.T) {
-			testrunner.New(nil).
-				Begin(t).
-				Prepare(
-					commands.OpenAccount{
-						CustomerID:  "C001",
-						AccountID:   "A001",
-						AccountName: "Anna Smith",
-					}).
-				ExecuteCommand(
-					commands.Deposit{
+			t.Run(
+				"it deposits the funds into the account",
+				func(t *testing.T) {
+					testrunner.New(nil).
+						Begin(t).
+						Prepare(
+							commands.OpenAccount{
+								CustomerID:  "C001",
+								AccountID:   "A001",
+								AccountName: "Anna Smith",
+							}).
+						ExecuteCommand(
+							commands.Deposit{
+								TransactionID: "T001",
+								AccountID:     "A001",
+								Amount:        500,
+							},
+							EventRecorded(
+								events.DepositApproved{
+									TransactionID: "T001",
+									AccountID:     "A001",
+									Amount:        500,
+								},
+							),
+						).
+						// verify that funds are availalbe
+						ExecuteCommand(
+							commands.Withdraw{
+								TransactionID: "W001",
+								AccountID:     "A001",
+								Amount:        100,
+								ScheduledDate: "2001-02-03",
+							},
+							EventRecorded(
+								events.WithdrawalApproved{
+									TransactionID: "W001",
+									AccountID:     "A001",
+									Amount:        100,
+								},
+							),
+						)
+				},
+			)
+		},
+	)
+
+	t.Run(
+		"when the deposit has already started",
+		func(t *testing.T) {
+			t.Run(
+				"it does not start the deposit again",
+				func(t *testing.T) {
+					cmd := commands.Deposit{
 						TransactionID: "T001",
 						AccountID:     "A001",
 						Amount:        500,
-					},
-					EventRecorded(
-						events.DepositApproved{
-							TransactionID: "T001",
-							AccountID:     "A001",
-							Amount:        500,
-						},
-					),
-				).
-				// verify that funds are availalbe
-				ExecuteCommand(
-					commands.Withdraw{
-						TransactionID: "W001",
-						AccountID:     "A001",
-						Amount:        100,
-						ScheduledDate: "2001-02-03",
-					},
-					EventRecorded(
-						events.WithdrawalApproved{
-							TransactionID: "W001",
-							AccountID:     "A001",
-							Amount:        100,
-						},
-					),
-				)
+					}
+
+					testrunner.New(nil).
+						Begin(t).
+						Prepare(cmd).
+						ExecuteCommand(
+							cmd,
+							NoneOf(
+								EventTypeRecorded(events.DepositApproved{}),
+							),
+						)
+				},
+			)
 		},
 	)
 }

--- a/domain/transfer_test.go
+++ b/domain/transfer_test.go
@@ -339,4 +339,60 @@ func Test_Transfer(t *testing.T) {
 			)
 		},
 	)
+
+	t.Run(
+		"when the transfer is to the same account",
+		func(t *testing.T) {
+			t.Run(
+				"it does not start the transfer",
+				func(t *testing.T) {
+					cmd := commands.Transfer{
+						TransactionID: "T001",
+						FromAccountID: "A001",
+						ToAccountID:   "A001",
+						Amount:        100,
+						ScheduledDate: "2001-02-04",
+					}
+
+					testrunner.New(nil).
+						Begin(t).
+						Prepare(cmd).
+						ExecuteCommand(
+							cmd,
+							NoneOf(
+								EventTypeRecorded(events.WithdrawalApproved{}),
+							),
+						)
+				},
+			)
+		},
+	)
+
+	t.Run(
+		"when the transfer has already started",
+		func(t *testing.T) {
+			t.Run(
+				"it does not start the transfer again",
+				func(t *testing.T) {
+					cmd := commands.Transfer{
+						TransactionID: "T001",
+						FromAccountID: "A001",
+						ToAccountID:   "A002",
+						Amount:        100,
+						ScheduledDate: "2001-02-04",
+					}
+
+					testrunner.New(nil).
+						Begin(t).
+						Prepare(cmd).
+						ExecuteCommand(
+							cmd,
+							NoneOf(
+								EventTypeRecorded(events.WithdrawalApproved{}),
+							),
+						)
+				},
+			)
+		},
+	)
 }

--- a/domain/withdrawal_test.go
+++ b/domain/withdrawal_test.go
@@ -268,4 +268,31 @@ func Test_Withdraw(t *testing.T) {
 			)
 		},
 	)
+
+	t.Run(
+		"when the withdrawal has already started",
+		func(t *testing.T) {
+			t.Run(
+				"it does not start the withdrawal again",
+				func(t *testing.T) {
+					cmd := commands.Withdraw{
+						TransactionID: "T001",
+						AccountID:     "A001",
+						Amount:        expectedDailyDebitLimit + 1,
+						ScheduledDate: "2001-02-03",
+					}
+
+					testrunner.New(nil).
+						Begin(t).
+						Prepare(cmd).
+						ExecuteCommand(
+							cmd,
+							NoneOf(
+								EventTypeRecorded(events.WithdrawalApproved{}),
+							),
+						)
+				},
+			)
+		},
+	)
 }


### PR DESCRIPTION
#### What change does this introduce?

Aggregate standalone global functions will be changed to be methods on the aggregates.

#### Why make this change?

To follow our common style and make it clear which methods are part of the aggregate public api to be used by the handler.

#### What approach will be taken?

- Functions will be converted to methods of the aggregates
- Aggregate public api methods will be renamed to be "exported"
- Some missing tests will be added to improve coverage

#### What issues does this relate to?

N/A
