### PR TITLE
Add MessageDescription methods for all messages

### DIFF
--- a/messages/commands/account.go
+++ b/messages/commands/account.go
@@ -54,7 +54,7 @@ func (m OpenAccountForNewCustomer) MessageDescription() string {
 // MessageDescription returns a human-readable description of the message.
 func (m OpenAccount) MessageDescription() string {
 	return fmt.Sprintf(
-		"account %s %s is being opened for customer %s",
+		"opening account %s %s for customer %s",
 		m.AccountID,
 		m.AccountName,
 		m.CustomerID,

--- a/messages/commands/account.go
+++ b/messages/commands/account.go
@@ -52,7 +52,7 @@ func (m *OpenAccountForNewCustomer) MessageDescription() string {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *OpenAccount) String() string {
+func (m *OpenAccount) MessageDescription() string {
 	return fmt.Sprintf(
 		"account %s %s is being opened for customer %s",
 		m.AccountID,
@@ -62,7 +62,7 @@ func (m *OpenAccount) String() string {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *CreditAccount) String() string {
+func (m *CreditAccount) MessageDescription() string {
 	return fmt.Sprintf(
 		"crediting %s to account %s",
 		messages.FormatAmount(m.Amount),
@@ -71,7 +71,7 @@ func (m *CreditAccount) String() string {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *DebitAccount) String() string {
+func (m *DebitAccount) MessageDescription() string {
 	return fmt.Sprintf(
 		"debiting %s from account %s",
 		messages.FormatAmount(m.Amount),

--- a/messages/commands/account.go
+++ b/messages/commands/account.go
@@ -1,6 +1,10 @@
 package commands
 
-import "github.com/dogmatiq/example/messages"
+import (
+	"fmt"
+
+	"github.com/dogmatiq/example/messages"
+)
 
 // OpenAccountForNewCustomer is a command requesting that a new bank account be
 // opened for a new customer.
@@ -34,4 +38,43 @@ type DebitAccount struct {
 	TransactionType messages.TransactionType
 	Amount          int64
 	ScheduledDate   string
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *OpenAccountForNewCustomer) MessageDescription() string {
+	return fmt.Sprintf(
+		"customer %s %s is opening their first account %s %s",
+		messages.FormatID(m.CustomerID),
+		m.CustomerName,
+		messages.FormatID(m.AccountID),
+		m.AccountName,
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *OpenAccount) String() string {
+	return fmt.Sprintf(
+		"account %s %s is being opened for customer %s",
+		messages.FormatID(m.AccountID),
+		m.AccountName,
+		messages.FormatID(m.CustomerID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *CreditAccount) String() string {
+	return fmt.Sprintf(
+		"crediting %s to account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *DebitAccount) String() string {
+	return fmt.Sprintf(
+		"debiting %s from account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+	)
 }

--- a/messages/commands/account.go
+++ b/messages/commands/account.go
@@ -44,9 +44,9 @@ type DebitAccount struct {
 func (m *OpenAccountForNewCustomer) MessageDescription() string {
 	return fmt.Sprintf(
 		"customer %s %s is opening their first account %s %s",
-		messages.FormatID(m.CustomerID),
+		m.CustomerID,
 		m.CustomerName,
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 		m.AccountName,
 	)
 }
@@ -55,9 +55,9 @@ func (m *OpenAccountForNewCustomer) MessageDescription() string {
 func (m *OpenAccount) String() string {
 	return fmt.Sprintf(
 		"account %s %s is being opened for customer %s",
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 		m.AccountName,
-		messages.FormatID(m.CustomerID),
+		m.CustomerID,
 	)
 }
 
@@ -66,7 +66,7 @@ func (m *CreditAccount) String() string {
 	return fmt.Sprintf(
 		"crediting %s to account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 	)
 }
 
@@ -75,6 +75,6 @@ func (m *DebitAccount) String() string {
 	return fmt.Sprintf(
 		"debiting %s from account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 	)
 }

--- a/messages/commands/account.go
+++ b/messages/commands/account.go
@@ -41,7 +41,7 @@ type DebitAccount struct {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *OpenAccountForNewCustomer) MessageDescription() string {
+func (m OpenAccountForNewCustomer) MessageDescription() string {
 	return fmt.Sprintf(
 		"customer %s %s is opening their first account %s %s",
 		m.CustomerID,
@@ -52,7 +52,7 @@ func (m *OpenAccountForNewCustomer) MessageDescription() string {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *OpenAccount) MessageDescription() string {
+func (m OpenAccount) MessageDescription() string {
 	return fmt.Sprintf(
 		"account %s %s is being opened for customer %s",
 		m.AccountID,
@@ -62,18 +62,22 @@ func (m *OpenAccount) MessageDescription() string {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *CreditAccount) MessageDescription() string {
+func (m CreditAccount) MessageDescription() string {
 	return fmt.Sprintf(
-		"crediting %s to account %s",
+		"%s %s: crediting %s to account %s",
+		m.TransactionType,
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *DebitAccount) MessageDescription() string {
+func (m DebitAccount) MessageDescription() string {
 	return fmt.Sprintf(
-		"debiting %s from account %s",
+		"%s %s: debiting %s from account %s",
+		m.TransactionType,
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)

--- a/messages/commands/dailydebitlimit.go
+++ b/messages/commands/dailydebitlimit.go
@@ -19,9 +19,9 @@ type ConsumeDailyDebitLimit struct {
 // MessageDescription returns a human-readable description of the message.
 func (m *ConsumeDailyDebitLimit) MessageDescription() string {
 	return fmt.Sprintf(
-		"consuming %s from daily debit limit of account %s on date %s",
+		"consuming %s from %s daily debit limit for account %s",
 		messages.FormatAmount(m.Amount),
-		m.AccountID,
 		m.ScheduledDate,
+		m.AccountID,
 	)
 }

--- a/messages/commands/dailydebitlimit.go
+++ b/messages/commands/dailydebitlimit.go
@@ -21,7 +21,7 @@ func (m *ConsumeDailyDebitLimit) MessageDescription() string {
 	return fmt.Sprintf(
 		"consuming %s from daily debit limit of account %s on date %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 		m.ScheduledDate,
 	)
 }

--- a/messages/commands/dailydebitlimit.go
+++ b/messages/commands/dailydebitlimit.go
@@ -1,6 +1,10 @@
 package commands
 
-import "github.com/dogmatiq/example/messages"
+import (
+	"fmt"
+
+	"github.com/dogmatiq/example/messages"
+)
 
 // ConsumeDailyDebitLimit is a command requesting that an amount of an account
 // daily debit limit be consumed.
@@ -10,4 +14,14 @@ type ConsumeDailyDebitLimit struct {
 	DebitType     messages.TransactionType
 	Amount        int64
 	ScheduledDate string
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *ConsumeDailyDebitLimit) MessageDescription() string {
+	return fmt.Sprintf(
+		"consuming %s from daily debit limit of account %s on date %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+		m.ScheduledDate,
+	)
 }

--- a/messages/commands/dailydebitlimit.go
+++ b/messages/commands/dailydebitlimit.go
@@ -17,9 +17,11 @@ type ConsumeDailyDebitLimit struct {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *ConsumeDailyDebitLimit) MessageDescription() string {
+func (m ConsumeDailyDebitLimit) MessageDescription() string {
 	return fmt.Sprintf(
-		"consuming %s from %s daily debit limit for account %s",
+		"%s %s: consuming %s from %s daily debit limit of account %s",
+		m.DebitType,
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.ScheduledDate,
 		m.AccountID,

--- a/messages/commands/deposit.go
+++ b/messages/commands/deposit.go
@@ -25,7 +25,7 @@ func (m *Deposit) MessageDescription() string {
 	return fmt.Sprintf(
 		"depositing %s into account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 	)
 }
 
@@ -34,6 +34,6 @@ func (m *ApproveDeposit) MessageDescription() string {
 	return fmt.Sprintf(
 		"approving deposit of %s into account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 	)
 }

--- a/messages/commands/deposit.go
+++ b/messages/commands/deposit.go
@@ -21,18 +21,20 @@ type ApproveDeposit struct {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *Deposit) MessageDescription() string {
+func (m Deposit) MessageDescription() string {
 	return fmt.Sprintf(
-		"depositing %s into account %s",
+		"deposit %s: depositing %s into account %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *ApproveDeposit) MessageDescription() string {
+func (m ApproveDeposit) MessageDescription() string {
 	return fmt.Sprintf(
-		"approving deposit of %s into account %s",
+		"deposit %s: approving deposit of %s into account %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)

--- a/messages/commands/deposit.go
+++ b/messages/commands/deposit.go
@@ -1,5 +1,11 @@
 package commands
 
+import (
+	"fmt"
+
+	"github.com/dogmatiq/example/messages"
+)
+
 // Deposit is a command requesting that funds be deposited into a bank account.
 type Deposit struct {
 	TransactionID string
@@ -12,4 +18,22 @@ type ApproveDeposit struct {
 	TransactionID string
 	AccountID     string
 	Amount        int64
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *Deposit) MessageDescription() string {
+	return fmt.Sprintf(
+		"depositing %s into account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *ApproveDeposit) MessageDescription() string {
+	return fmt.Sprintf(
+		"approving deposit of %s into account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+	)
 }

--- a/messages/commands/transfer.go
+++ b/messages/commands/transfer.go
@@ -34,9 +34,10 @@ type DeclineTransfer struct {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *Transfer) MessageDescription() string {
+func (m Transfer) MessageDescription() string {
 	return fmt.Sprintf(
-		"transfering %s from account %s to account %s",
+		"transfer %s: transfering %s from account %s to account %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.FromAccountID,
 		m.ToAccountID,
@@ -44,9 +45,10 @@ func (m *Transfer) MessageDescription() string {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *ApproveTransfer) MessageDescription() string {
+func (m ApproveTransfer) MessageDescription() string {
 	return fmt.Sprintf(
-		"approving transfer of %s from account %s to account %s",
+		"transfer %s: approving transfer of %s from account %s to account %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.FromAccountID,
 		m.ToAccountID,
@@ -54,9 +56,10 @@ func (m *ApproveTransfer) MessageDescription() string {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *DeclineTransfer) MessageDescription() string {
+func (m DeclineTransfer) MessageDescription() string {
 	return fmt.Sprintf(
-		"declining transfer of %s from account %s to account %s: %s",
+		"transfer %s: declining transfer of %s from account %s to account %s: %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.FromAccountID,
 		m.ToAccountID,

--- a/messages/commands/transfer.go
+++ b/messages/commands/transfer.go
@@ -60,6 +60,6 @@ func (m *DeclineTransfer) MessageDescription() string {
 		messages.FormatAmount(m.Amount),
 		m.FromAccountID,
 		m.ToAccountID,
-		m.Reason.String(),
+		m.Reason,
 	)
 }

--- a/messages/commands/transfer.go
+++ b/messages/commands/transfer.go
@@ -38,8 +38,8 @@ func (m *Transfer) MessageDescription() string {
 	return fmt.Sprintf(
 		"transfering %s from account %s to account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.FromAccountID),
-		messages.FormatID(m.ToAccountID),
+		m.FromAccountID,
+		m.ToAccountID,
 	)
 }
 
@@ -48,8 +48,8 @@ func (m *ApproveTransfer) MessageDescription() string {
 	return fmt.Sprintf(
 		"approving transfer of %s from account %s to account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.FromAccountID),
-		messages.FormatID(m.ToAccountID),
+		m.FromAccountID,
+		m.ToAccountID,
 	)
 }
 
@@ -58,8 +58,8 @@ func (m *DeclineTransfer) MessageDescription() string {
 	return fmt.Sprintf(
 		"declining transfer of %s from account %s to account %s for reason %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.FromAccountID),
-		messages.FormatID(m.ToAccountID),
+		m.FromAccountID,
+		m.ToAccountID,
 		m.Reason,
 	)
 }

--- a/messages/commands/transfer.go
+++ b/messages/commands/transfer.go
@@ -1,6 +1,10 @@
 package commands
 
-import "github.com/dogmatiq/example/messages"
+import (
+	"fmt"
+
+	"github.com/dogmatiq/example/messages"
+)
 
 // Transfer is a command requesting that funds be transferred from one bank
 // account to another.
@@ -27,4 +31,35 @@ type DeclineTransfer struct {
 	ToAccountID   string
 	Amount        int64
 	Reason        messages.DebitFailureReason
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *Transfer) MessageDescription() string {
+	return fmt.Sprintf(
+		"transfering %s from account %s to account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.FromAccountID),
+		messages.FormatID(m.ToAccountID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *ApproveTransfer) MessageDescription() string {
+	return fmt.Sprintf(
+		"approving transfer of %s from account %s to account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.FromAccountID),
+		messages.FormatID(m.ToAccountID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *DeclineTransfer) MessageDescription() string {
+	return fmt.Sprintf(
+		"declining transfer of %s from account %s to account %s for reason %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.FromAccountID),
+		messages.FormatID(m.ToAccountID),
+		m.Reason,
+	)
 }

--- a/messages/commands/transfer.go
+++ b/messages/commands/transfer.go
@@ -56,10 +56,10 @@ func (m *ApproveTransfer) MessageDescription() string {
 // MessageDescription returns a human-readable description of the message.
 func (m *DeclineTransfer) MessageDescription() string {
 	return fmt.Sprintf(
-		"declining transfer of %s from account %s to account %s for reason %s",
+		"declining transfer of %s from account %s to account %s: %s",
 		messages.FormatAmount(m.Amount),
 		m.FromAccountID,
 		m.ToAccountID,
-		m.Reason,
+		m.Reason.String(),
 	)
 }

--- a/messages/commands/withdrawal.go
+++ b/messages/commands/withdrawal.go
@@ -50,9 +50,9 @@ func (m *ApproveWithdrawal) MessageDescription() string {
 // MessageDescription returns a human-readable description of the message.
 func (m *DeclineWithdrawal) MessageDescription() string {
 	return fmt.Sprintf(
-		"declining withdrawal of %s from account %s for reason %s",
+		"declining withdrawal of %s from account %s: %s",
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
-		m.Reason,
+		m.Reason.String(),
 	)
 }

--- a/messages/commands/withdrawal.go
+++ b/messages/commands/withdrawal.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/dogmatiq/example/messages"
 )
 
@@ -25,4 +27,32 @@ type DeclineWithdrawal struct {
 	AccountID     string
 	Amount        int64
 	Reason        messages.DebitFailureReason
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *Withdraw) MessageDescription() string {
+	return fmt.Sprintf(
+		"withdrawing %s from account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *ApproveWithdrawal) MessageDescription() string {
+	return fmt.Sprintf(
+		"approving withdrawal of %s from account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *DeclineWithdrawal) MessageDescription() string {
+	return fmt.Sprintf(
+		"declining withdrawal of %s from account %s for reason %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+		m.Reason,
+	)
 }

--- a/messages/commands/withdrawal.go
+++ b/messages/commands/withdrawal.go
@@ -53,6 +53,6 @@ func (m *DeclineWithdrawal) MessageDescription() string {
 		"declining withdrawal of %s from account %s: %s",
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
-		m.Reason.String(),
+		m.Reason,
 	)
 }

--- a/messages/commands/withdrawal.go
+++ b/messages/commands/withdrawal.go
@@ -34,7 +34,7 @@ func (m *Withdraw) MessageDescription() string {
 	return fmt.Sprintf(
 		"withdrawing %s from account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 	)
 }
 
@@ -43,7 +43,7 @@ func (m *ApproveWithdrawal) MessageDescription() string {
 	return fmt.Sprintf(
 		"approving withdrawal of %s from account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 	)
 }
 
@@ -52,7 +52,7 @@ func (m *DeclineWithdrawal) MessageDescription() string {
 	return fmt.Sprintf(
 		"declining withdrawal of %s from account %s for reason %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 		m.Reason,
 	)
 }

--- a/messages/commands/withdrawal.go
+++ b/messages/commands/withdrawal.go
@@ -30,27 +30,30 @@ type DeclineWithdrawal struct {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *Withdraw) MessageDescription() string {
+func (m Withdraw) MessageDescription() string {
 	return fmt.Sprintf(
-		"withdrawing %s from account %s",
+		"withdrawal %s: withdrawing %s from account %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *ApproveWithdrawal) MessageDescription() string {
+func (m ApproveWithdrawal) MessageDescription() string {
 	return fmt.Sprintf(
-		"approving withdrawal of %s from account %s",
+		"withdrawal %s: approving withdrawal of %s from account %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *DeclineWithdrawal) MessageDescription() string {
+func (m DeclineWithdrawal) MessageDescription() string {
 	return fmt.Sprintf(
-		"declining withdrawal of %s from account %s: %s",
+		"withdrawal %s: declining withdrawal of %s from account %s: %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 		m.Reason,

--- a/messages/events/account.go
+++ b/messages/events/account.go
@@ -1,6 +1,10 @@
 package events
 
-import "github.com/dogmatiq/example/messages"
+import (
+	"fmt"
+
+	"github.com/dogmatiq/example/messages"
+)
 
 // AccountOpened is an event indicating that a new bank account has been opened.
 type AccountOpened struct {
@@ -34,4 +38,42 @@ type AccountDebitDeclined struct {
 	TransactionType messages.TransactionType
 	Amount          int64
 	Reason          messages.DebitFailureReason
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *AccountOpened) MessageDescription() string {
+	return fmt.Sprintf(
+		"account %s %s opened for customer %s",
+		messages.FormatID(m.AccountID),
+		m.AccountName,
+		messages.FormatID(m.CustomerID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *AccountCredited) MessageDescription() string {
+	return fmt.Sprintf(
+		"credited %s to account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *AccountDebited) MessageDescription() string {
+	return fmt.Sprintf(
+		"debited %s from account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *AccountDebitDeclined) MessageDescription() string {
+	return fmt.Sprintf(
+		"declined debit of %s from account %s for reason %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+		m.Reason,
+	)
 }

--- a/messages/events/account.go
+++ b/messages/events/account.go
@@ -43,7 +43,7 @@ type AccountDebitDeclined struct {
 // MessageDescription returns a human-readable description of the message.
 func (m AccountOpened) MessageDescription() string {
 	return fmt.Sprintf(
-		"account %s %s opened for customer %s",
+		"opened account %s %s for customer %s",
 		m.AccountID,
 		m.AccountName,
 		m.CustomerID,

--- a/messages/events/account.go
+++ b/messages/events/account.go
@@ -44,9 +44,9 @@ type AccountDebitDeclined struct {
 func (m *AccountOpened) MessageDescription() string {
 	return fmt.Sprintf(
 		"account %s %s opened for customer %s",
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 		m.AccountName,
-		messages.FormatID(m.CustomerID),
+		m.CustomerID,
 	)
 }
 
@@ -55,7 +55,7 @@ func (m *AccountCredited) MessageDescription() string {
 	return fmt.Sprintf(
 		"credited %s to account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 	)
 }
 
@@ -64,7 +64,7 @@ func (m *AccountDebited) MessageDescription() string {
 	return fmt.Sprintf(
 		"debited %s from account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 	)
 }
 
@@ -73,7 +73,7 @@ func (m *AccountDebitDeclined) MessageDescription() string {
 	return fmt.Sprintf(
 		"declined debit of %s from account %s for reason %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 		m.Reason,
 	)
 }

--- a/messages/events/account.go
+++ b/messages/events/account.go
@@ -71,9 +71,9 @@ func (m *AccountDebited) MessageDescription() string {
 // MessageDescription returns a human-readable description of the message.
 func (m *AccountDebitDeclined) MessageDescription() string {
 	return fmt.Sprintf(
-		"declined debit of %s from account %s for reason %s",
+		"declined debit of %s from account %s: %s",
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
-		m.Reason,
+		m.Reason.String(),
 	)
 }

--- a/messages/events/account.go
+++ b/messages/events/account.go
@@ -74,6 +74,6 @@ func (m *AccountDebitDeclined) MessageDescription() string {
 		"declined debit of %s from account %s: %s",
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
-		m.Reason.String(),
+		m.Reason,
 	)
 }

--- a/messages/events/account.go
+++ b/messages/events/account.go
@@ -41,7 +41,7 @@ type AccountDebitDeclined struct {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *AccountOpened) MessageDescription() string {
+func (m AccountOpened) MessageDescription() string {
 	return fmt.Sprintf(
 		"account %s %s opened for customer %s",
 		m.AccountID,
@@ -51,27 +51,33 @@ func (m *AccountOpened) MessageDescription() string {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *AccountCredited) MessageDescription() string {
+func (m AccountCredited) MessageDescription() string {
 	return fmt.Sprintf(
-		"credited %s to account %s",
+		"%s %s: credited %s to account %s",
+		m.TransactionType,
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *AccountDebited) MessageDescription() string {
+func (m AccountDebited) MessageDescription() string {
 	return fmt.Sprintf(
-		"debited %s from account %s",
+		"%s %s: debited %s from account %s",
+		m.TransactionType,
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *AccountDebitDeclined) MessageDescription() string {
+func (m AccountDebitDeclined) MessageDescription() string {
 	return fmt.Sprintf(
-		"declined debit of %s from account %s: %s",
+		"%s %s: declined debit of %s from account %s: %s",
+		m.TransactionType,
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 		m.Reason,

--- a/messages/events/customer.go
+++ b/messages/events/customer.go
@@ -14,7 +14,7 @@ type CustomerAcquired struct {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *CustomerAcquired) MessageDescription() string {
+func (m CustomerAcquired) MessageDescription() string {
 	return fmt.Sprintf(
 		"acquired customer %s %s with first account %s %s",
 		m.CustomerID,

--- a/messages/events/customer.go
+++ b/messages/events/customer.go
@@ -2,8 +2,6 @@ package events
 
 import (
 	"fmt"
-
-	"github.com/dogmatiq/example/messages"
 )
 
 // CustomerAcquired is an event indicating that a new customer has been
@@ -19,9 +17,9 @@ type CustomerAcquired struct {
 func (m *CustomerAcquired) MessageDescription() string {
 	return fmt.Sprintf(
 		"acquired customer %s %s with first account %s %s",
-		messages.FormatID(m.CustomerID),
+		m.CustomerID,
 		m.CustomerName,
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 		m.AccountName,
 	)
 }

--- a/messages/events/customer.go
+++ b/messages/events/customer.go
@@ -16,10 +16,8 @@ type CustomerAcquired struct {
 // MessageDescription returns a human-readable description of the message.
 func (m CustomerAcquired) MessageDescription() string {
 	return fmt.Sprintf(
-		"acquired customer %s %s with first account %s %s",
+		"acquired customer %s %s,
 		m.CustomerID,
 		m.CustomerName,
-		m.AccountID,
-		m.AccountName,
 	)
 }

--- a/messages/events/customer.go
+++ b/messages/events/customer.go
@@ -16,7 +16,7 @@ type CustomerAcquired struct {
 // MessageDescription returns a human-readable description of the message.
 func (m CustomerAcquired) MessageDescription() string {
 	return fmt.Sprintf(
-		"acquired customer %s %s,
+		"acquired customer %s %s",
 		m.CustomerID,
 		m.CustomerName,
 	)

--- a/messages/events/customer.go
+++ b/messages/events/customer.go
@@ -1,5 +1,11 @@
 package events
 
+import (
+	"fmt"
+
+	"github.com/dogmatiq/example/messages"
+)
+
 // CustomerAcquired is an event indicating that a new customer has been
 // acquired.
 type CustomerAcquired struct {
@@ -7,4 +13,15 @@ type CustomerAcquired struct {
 	CustomerName string
 	AccountID    string
 	AccountName  string
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *CustomerAcquired) MessageDescription() string {
+	return fmt.Sprintf(
+		"acquired customer %s %s with first account %s %s",
+		messages.FormatID(m.CustomerID),
+		m.CustomerName,
+		messages.FormatID(m.AccountID),
+		m.AccountName,
+	)
 }

--- a/messages/events/dailydebitlimit.go
+++ b/messages/events/dailydebitlimit.go
@@ -31,7 +31,7 @@ type DailyDebitLimitExceeded struct {
 // MessageDescription returns a human-readable description of the message.
 func (m *DailyDebitLimitConsumed) MessageDescription() string {
 	return fmt.Sprintf(
-		"consumed %s from daily debit limit of account %s",
+		"consumed %s from daily debit limit for account %s",
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)
@@ -40,7 +40,7 @@ func (m *DailyDebitLimitConsumed) MessageDescription() string {
 // MessageDescription returns a human-readable description of the message.
 func (m *DailyDebitLimitExceeded) MessageDescription() string {
 	return fmt.Sprintf(
-		"consuming %s from daily debit limit of account %s was denied for exceeding limit",
+		"consuming %s from daily debit limit for account %s was denied for exceeding limit",
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)

--- a/messages/events/dailydebitlimit.go
+++ b/messages/events/dailydebitlimit.go
@@ -33,7 +33,7 @@ func (m *DailyDebitLimitConsumed) MessageDescription() string {
 	return fmt.Sprintf(
 		"consumed %s from daily debit limit of account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 	)
 }
 
@@ -42,6 +42,6 @@ func (m *DailyDebitLimitExceeded) MessageDescription() string {
 	return fmt.Sprintf(
 		"consuming %s from daily debit limit of account %s was denied for exceeding limit",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 	)
 }

--- a/messages/events/dailydebitlimit.go
+++ b/messages/events/dailydebitlimit.go
@@ -29,19 +29,23 @@ type DailyDebitLimitExceeded struct {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *DailyDebitLimitConsumed) MessageDescription() string {
+func (m DailyDebitLimitConsumed) MessageDescription() string {
 	return fmt.Sprintf(
-		"consumed %s from daily debit limit for account %s",
+		"%s %s: consumed %s from daily debit limit of account %s",
+		m.DebitType,
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *DailyDebitLimitExceeded) MessageDescription() string {
+func (m DailyDebitLimitExceeded) MessageDescription() string {
 	return fmt.Sprintf(
-		"consuming %s from daily debit limit for account %s was denied for exceeding limit",
-		messages.FormatAmount(m.Amount),
+		"%s %s: exceeded daily debit limit of account %s by %s",
+		m.DebitType,
+		m.TransactionID,
 		m.AccountID,
+		messages.FormatAmount((m.LimitUsed+m.Amount)-m.LimitMaximum),
 	)
 }

--- a/messages/events/dailydebitlimit.go
+++ b/messages/events/dailydebitlimit.go
@@ -1,6 +1,10 @@
 package events
 
-import "github.com/dogmatiq/example/messages"
+import (
+	"fmt"
+
+	"github.com/dogmatiq/example/messages"
+)
 
 // DailyDebitLimitConsumed is an event that indicates an amount of an account
 // daily debit limit has been consumed.
@@ -22,4 +26,22 @@ type DailyDebitLimitExceeded struct {
 	Amount        int64
 	LimitUsed     int64
 	LimitMaximum  int64
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *DailyDebitLimitConsumed) MessageDescription() string {
+	return fmt.Sprintf(
+		"consumed %s from daily debit limit of account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *DailyDebitLimitExceeded) MessageDescription() string {
+	return fmt.Sprintf(
+		"consuming %s from daily debit limit of account %s was denied for exceeding limit",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+	)
 }

--- a/messages/events/deposit.go
+++ b/messages/events/deposit.go
@@ -23,7 +23,7 @@ type DepositApproved struct {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *DepositStarted) String() string {
+func (m *DepositStarted) MessageDescription() string {
 	return fmt.Sprintf(
 		"started deposit of %s into account %s",
 		messages.FormatAmount(m.Amount),
@@ -32,7 +32,7 @@ func (m *DepositStarted) String() string {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *DepositApproved) String() string {
+func (m *DepositApproved) MessageDescription() string {
 	return fmt.Sprintf(
 		"approved deposit of %s into account %s",
 		messages.FormatAmount(m.Amount),

--- a/messages/events/deposit.go
+++ b/messages/events/deposit.go
@@ -23,18 +23,20 @@ type DepositApproved struct {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *DepositStarted) MessageDescription() string {
+func (m DepositStarted) MessageDescription() string {
 	return fmt.Sprintf(
-		"started deposit of %s into account %s",
+		"deposit %s: started deposit of %s into account %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *DepositApproved) MessageDescription() string {
+func (m DepositApproved) MessageDescription() string {
 	return fmt.Sprintf(
-		"approved deposit of %s into account %s",
+		"deposit %s: approved deposit of %s into account %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)

--- a/messages/events/deposit.go
+++ b/messages/events/deposit.go
@@ -27,7 +27,7 @@ func (m *DepositStarted) String() string {
 	return fmt.Sprintf(
 		"started deposit of %s into account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 	)
 }
 
@@ -36,6 +36,6 @@ func (m *DepositApproved) String() string {
 	return fmt.Sprintf(
 		"approved deposit of %s into account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 	)
 }

--- a/messages/events/deposit.go
+++ b/messages/events/deposit.go
@@ -1,5 +1,11 @@
 package events
 
+import (
+	"fmt"
+
+	"github.com/dogmatiq/example/messages"
+)
+
 // DepositStarted is an event indicating that the process of depositing funds
 // into an account has begun.
 type DepositStarted struct {
@@ -14,4 +20,22 @@ type DepositApproved struct {
 	TransactionID string
 	AccountID     string
 	Amount        int64
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *DepositStarted) String() string {
+	return fmt.Sprintf(
+		"started deposit of %s into account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *DepositApproved) String() string {
+	return fmt.Sprintf(
+		"approved deposit of %s into account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+	)
 }

--- a/messages/events/transfer.go
+++ b/messages/events/transfer.go
@@ -36,9 +36,10 @@ type TransferDeclined struct {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *TransferStarted) MessageDescription() string {
+func (m TransferStarted) MessageDescription() string {
 	return fmt.Sprintf(
-		"started transfer of %s from account %s to account %s",
+		"transfer %s: started transfer of %s from account %s to account %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.FromAccountID,
 		m.ToAccountID,
@@ -46,9 +47,10 @@ func (m *TransferStarted) MessageDescription() string {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *TransferApproved) MessageDescription() string {
+func (m TransferApproved) MessageDescription() string {
 	return fmt.Sprintf(
-		"approved transfer of %s from account %s to account %s",
+		"transfer %s: approved transfer of %s from account %s to account %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.FromAccountID,
 		m.ToAccountID,
@@ -56,9 +58,10 @@ func (m *TransferApproved) MessageDescription() string {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *TransferDeclined) MessageDescription() string {
+func (m TransferDeclined) MessageDescription() string {
 	return fmt.Sprintf(
-		"declined transfer of %s from account %s to account %s: %s",
+		"transfer %s: declined transfer of %s from account %s to account %s: %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.FromAccountID,
 		m.ToAccountID,

--- a/messages/events/transfer.go
+++ b/messages/events/transfer.go
@@ -62,6 +62,6 @@ func (m *TransferDeclined) MessageDescription() string {
 		messages.FormatAmount(m.Amount),
 		m.FromAccountID,
 		m.ToAccountID,
-		m.Reason.String(),
+		m.Reason,
 	)
 }

--- a/messages/events/transfer.go
+++ b/messages/events/transfer.go
@@ -40,8 +40,8 @@ func (m *TransferStarted) MessageDescription() string {
 	return fmt.Sprintf(
 		"started transfer of %s from account %s to account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.FromAccountID),
-		messages.FormatID(m.ToAccountID),
+		m.FromAccountID,
+		m.ToAccountID,
 	)
 }
 
@@ -50,8 +50,8 @@ func (m *TransferApproved) MessageDescription() string {
 	return fmt.Sprintf(
 		"approved transfer of %s from account %s to account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.FromAccountID),
-		messages.FormatID(m.ToAccountID),
+		m.FromAccountID,
+		m.ToAccountID,
 	)
 }
 
@@ -60,8 +60,8 @@ func (m *TransferDeclined) MessageDescription() string {
 	return fmt.Sprintf(
 		"declined transfer of %s from account %s to account %s for reason %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.FromAccountID),
-		messages.FormatID(m.ToAccountID),
+		m.FromAccountID,
+		m.ToAccountID,
 		m.Reason,
 	)
 }

--- a/messages/events/transfer.go
+++ b/messages/events/transfer.go
@@ -58,10 +58,10 @@ func (m *TransferApproved) MessageDescription() string {
 // MessageDescription returns a human-readable description of the message.
 func (m *TransferDeclined) MessageDescription() string {
 	return fmt.Sprintf(
-		"declined transfer of %s from account %s to account %s for reason %s",
+		"declined transfer of %s from account %s to account %s: %s",
 		messages.FormatAmount(m.Amount),
 		m.FromAccountID,
 		m.ToAccountID,
-		m.Reason,
+		m.Reason.String(),
 	)
 }

--- a/messages/events/transfer.go
+++ b/messages/events/transfer.go
@@ -1,6 +1,10 @@
 package events
 
-import "github.com/dogmatiq/example/messages"
+import (
+	"fmt"
+
+	"github.com/dogmatiq/example/messages"
+)
 
 // TransferStarted is an event indicating that the process of transferring funds
 // from one account to another has begun.
@@ -29,4 +33,35 @@ type TransferDeclined struct {
 	ToAccountID   string
 	Amount        int64
 	Reason        messages.DebitFailureReason
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *TransferStarted) MessageDescription() string {
+	return fmt.Sprintf(
+		"started transfer of %s from account %s to account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.FromAccountID),
+		messages.FormatID(m.ToAccountID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *TransferApproved) MessageDescription() string {
+	return fmt.Sprintf(
+		"approved transfer of %s from account %s to account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.FromAccountID),
+		messages.FormatID(m.ToAccountID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *TransferDeclined) MessageDescription() string {
+	return fmt.Sprintf(
+		"declined transfer of %s from account %s to account %s for reason %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.FromAccountID),
+		messages.FormatID(m.ToAccountID),
+		m.Reason,
+	)
 }

--- a/messages/events/withdrawal.go
+++ b/messages/events/withdrawal.go
@@ -37,7 +37,7 @@ func (m *WithdrawalStarted) MessageDescription() string {
 	return fmt.Sprintf(
 		"started withdrawal of %s from account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 	)
 }
 
@@ -46,7 +46,7 @@ func (m *WithdrawalApproved) MessageDescription() string {
 	return fmt.Sprintf(
 		"approved withdrawal of %s from account %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 	)
 }
 
@@ -55,7 +55,7 @@ func (m *WithdrawalDeclined) MessageDescription() string {
 	return fmt.Sprintf(
 		"declined withdrawal of %s from account %s for reason %s",
 		messages.FormatAmount(m.Amount),
-		messages.FormatID(m.AccountID),
+		m.AccountID,
 		m.Reason,
 	)
 }

--- a/messages/events/withdrawal.go
+++ b/messages/events/withdrawal.go
@@ -56,6 +56,6 @@ func (m *WithdrawalDeclined) MessageDescription() string {
 		"declined withdrawal of %s from account %s: %s",
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
-		m.Reason.String(),
+		m.Reason,
 	)
 }

--- a/messages/events/withdrawal.go
+++ b/messages/events/withdrawal.go
@@ -33,27 +33,30 @@ type WithdrawalDeclined struct {
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *WithdrawalStarted) MessageDescription() string {
+func (m WithdrawalStarted) MessageDescription() string {
 	return fmt.Sprintf(
-		"started withdrawal of %s from account %s",
+		"withdrawal %s: started withdrawal of %s from account %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *WithdrawalApproved) MessageDescription() string {
+func (m WithdrawalApproved) MessageDescription() string {
 	return fmt.Sprintf(
-		"approved withdrawal of %s from account %s",
+		"withdrawal %s: approved withdrawal of %s from account %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)
 }
 
 // MessageDescription returns a human-readable description of the message.
-func (m *WithdrawalDeclined) MessageDescription() string {
+func (m WithdrawalDeclined) MessageDescription() string {
 	return fmt.Sprintf(
-		"declined withdrawal of %s from account %s: %s",
+		"withdrawal %s: declined withdrawal of %s from account %s: %s",
+		m.TransactionID,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 		m.Reason,

--- a/messages/events/withdrawal.go
+++ b/messages/events/withdrawal.go
@@ -1,6 +1,8 @@
 package events
 
 import (
+	"fmt"
+
 	"github.com/dogmatiq/example/messages"
 )
 
@@ -28,4 +30,32 @@ type WithdrawalDeclined struct {
 	AccountID     string
 	Amount        int64
 	Reason        messages.DebitFailureReason
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *WithdrawalStarted) MessageDescription() string {
+	return fmt.Sprintf(
+		"started withdrawal of %s from account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *WithdrawalApproved) MessageDescription() string {
+	return fmt.Sprintf(
+		"approved withdrawal of %s from account %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+	)
+}
+
+// MessageDescription returns a human-readable description of the message.
+func (m *WithdrawalDeclined) MessageDescription() string {
+	return fmt.Sprintf(
+		"declined withdrawal of %s from account %s for reason %s",
+		messages.FormatAmount(m.Amount),
+		messages.FormatID(m.AccountID),
+		m.Reason,
+	)
 }

--- a/messages/events/withdrawal.go
+++ b/messages/events/withdrawal.go
@@ -53,9 +53,9 @@ func (m *WithdrawalApproved) MessageDescription() string {
 // MessageDescription returns a human-readable description of the message.
 func (m *WithdrawalDeclined) MessageDescription() string {
 	return fmt.Sprintf(
-		"declined withdrawal of %s from account %s for reason %s",
+		"declined withdrawal of %s from account %s: %s",
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
-		m.Reason,
+		m.Reason.String(),
 	)
 }

--- a/messages/format.go
+++ b/messages/format.go
@@ -1,0 +1,48 @@
+package messages
+
+import "fmt"
+
+// FormatAmount formats a cent amount as dollars.
+func FormatAmount(v int64) string {
+	f := "-$%d.%02d"
+	if v < 0 {
+		v = -v
+		f = "-" + f
+	}
+
+	return fmt.Sprintf(f, v/100, v%100)
+}
+
+// FormatID returns a compact rendering of ID for use in log messages and other
+// human-readable strings.
+// It returns '<unidentified>' if id is an empty string.
+func FormatID(id string) string {
+	if looksLikeUUID(id) {
+		return id[:uuidSep1] + id[uuidLen:]
+	}
+
+	if id == "" {
+		return "<unidentified>"
+	}
+
+	return id
+}
+
+func looksLikeUUID(id string) bool {
+	if len(id) < uuidLen {
+		return false
+	}
+
+	return id[uuidSep1] == '-' &&
+		id[uuidSep2] == '-' &&
+		id[uuidSep3] == '-' &&
+		id[uuidSep4] == '-'
+}
+
+const (
+	uuidLen  = 36
+	uuidSep1 = 8
+	uuidSep2 = 13
+	uuidSep3 = 18
+	uuidSep4 = 23
+)

--- a/messages/format.go
+++ b/messages/format.go
@@ -1,6 +1,8 @@
 package messages
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // FormatAmount formats a cent amount as dollars.
 func FormatAmount(v int64) string {
@@ -12,37 +14,3 @@ func FormatAmount(v int64) string {
 
 	return fmt.Sprintf(f, v/100, v%100)
 }
-
-// FormatID returns a compact rendering of ID for use in log messages and other
-// human-readable strings.
-// It returns '<unidentified>' if id is an empty string.
-func FormatID(id string) string {
-	if looksLikeUUID(id) {
-		return id[:uuidSep1] + id[uuidLen:]
-	}
-
-	if id == "" {
-		return "<unidentified>"
-	}
-
-	return id
-}
-
-func looksLikeUUID(id string) bool {
-	if len(id) < uuidLen {
-		return false
-	}
-
-	return id[uuidSep1] == '-' &&
-		id[uuidSep2] == '-' &&
-		id[uuidSep3] == '-' &&
-		id[uuidSep4] == '-'
-}
-
-const (
-	uuidLen  = 36
-	uuidSep1 = 8
-	uuidSep2 = 13
-	uuidSep3 = 18
-	uuidSep4 = 23
-)

--- a/messages/format.go
+++ b/messages/format.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // FormatAmount formats a cent amount as dollars.
 func FormatAmount(v int64) string {
-	f := "-$%d.%02d"
+	f := "$%d.%02d"
 	if v < 0 {
 		v = -v
 		f = "-" + f

--- a/messages/transaction.go
+++ b/messages/transaction.go
@@ -20,21 +20,9 @@ type DebitFailureReason string
 const (
 	// InsufficientFunds means there was not enough funds available in the
 	// account to perform the debit.
-	InsufficientFunds DebitFailureReason = "insufficent-funds"
+	InsufficientFunds DebitFailureReason = "insufficent funds"
 
 	// DailyDebitLimitExceeded means that the debit cannot be performed
 	// because it will exceed the account daily debit limit.
-	DailyDebitLimitExceeded DebitFailureReason = "daily-debit-limit-exceeded"
+	DailyDebitLimitExceeded DebitFailureReason = "daily debit limit exceeded"
 )
-
-// String returns a human-readable description of the reason.
-func (r DebitFailureReason) String() string {
-	switch r {
-	case InsufficientFunds:
-		return "insufficent funds"
-	case DailyDebitLimitExceeded:
-		return "daily debit limit exceeded"
-	default:
-		panic("unknown reason")
-	}
-}

--- a/messages/transaction.go
+++ b/messages/transaction.go
@@ -26,3 +26,15 @@ const (
 	// because it will exceed the account daily debit limit.
 	DailyDebitLimitExceeded DebitFailureReason = "daily-debit-limit-exceeded"
 )
+
+// String returns a human-readable description of the reason.
+func (r DebitFailureReason) String() string {
+	switch r {
+	case InsufficientFunds:
+		return "insufficent funds"
+	case DailyDebitLimitExceeded:
+		return "daily debit limit exceeded"
+	default:
+		panic("unknown reason")
+	}
+}


### PR DESCRIPTION
#### What change does this introduce?

<!-- Example:
A new type of desktop notification will now be triggered when a tournament
starts. An associated notification preference will also become available.
-->

The `MessageDescription() string` method will be added for each message type. This method is used to for logging.

#### Why make this change?

The existing message types currently do not have this method.

#### What approach will be taken?

A `MessageDescription() string` method will be added for each message type.

#### What issues does this relate to?

- Fixes #56 
