### PR TITLE
Use go v1.15 in CI configration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
       id: go
     - name: Checkout
       uses: actions/checkout@v1


### PR DESCRIPTION
fixes #67
