### PR TITLE
Add date to events about daily debit limit

### DIFF
--- a/domain/dailydebitlimit.go
+++ b/domain/dailydebitlimit.go
@@ -25,6 +25,7 @@ func (d *dailyDebitLimit) Consume(s dogma.AggregateCommandScope, m commands.Cons
 			AccountID:     m.AccountID,
 			DebitType:     m.DebitType,
 			Amount:        m.Amount,
+			Date:          m.ScheduledDate,
 			LimitUsed:     d.UsedAmount,
 			LimitMaximum:  maximumDailyDebitLimit,
 		})
@@ -34,6 +35,7 @@ func (d *dailyDebitLimit) Consume(s dogma.AggregateCommandScope, m commands.Cons
 			AccountID:     m.AccountID,
 			DebitType:     m.DebitType,
 			Amount:        m.Amount,
+			Date:          m.ScheduledDate,
 			LimitUsed:     d.UsedAmount + m.Amount,
 			LimitMaximum:  maximumDailyDebitLimit,
 		})

--- a/messages/events/dailydebitlimit.go
+++ b/messages/events/dailydebitlimit.go
@@ -13,6 +13,7 @@ type DailyDebitLimitConsumed struct {
 	AccountID     string
 	DebitType     messages.TransactionType
 	Amount        int64
+	Date          string
 	LimitUsed     int64
 	LimitMaximum  int64
 }
@@ -24,6 +25,7 @@ type DailyDebitLimitExceeded struct {
 	AccountID     string
 	DebitType     messages.TransactionType
 	Amount        int64
+	Date          string
 	LimitUsed     int64
 	LimitMaximum  int64
 }
@@ -31,9 +33,10 @@ type DailyDebitLimitExceeded struct {
 // MessageDescription returns a human-readable description of the message.
 func (m DailyDebitLimitConsumed) MessageDescription() string {
 	return fmt.Sprintf(
-		"%s %s: consumed %s from daily debit limit of account %s",
+		"%s %s: consumed %s from %s daily debit limit of account %s",
 		m.DebitType,
 		m.TransactionID,
+		m.Date,
 		messages.FormatAmount(m.Amount),
 		m.AccountID,
 	)
@@ -42,9 +45,10 @@ func (m DailyDebitLimitConsumed) MessageDescription() string {
 // MessageDescription returns a human-readable description of the message.
 func (m DailyDebitLimitExceeded) MessageDescription() string {
 	return fmt.Sprintf(
-		"%s %s: exceeded daily debit limit of account %s by %s",
+		"%s %s: exceeded %s daily debit limit of account %s by %s",
 		m.DebitType,
 		m.TransactionID,
+		m.Date,
 		m.AccountID,
 		messages.FormatAmount((m.LimitUsed+m.Amount)-m.LimitMaximum),
 	)


### PR DESCRIPTION
#### What change does this introduce?

This PR adds Date fields to the daily debit limit event messages. 

#### What issues does this relate to?

Fixes #80 

#### Why make this change?

The date is a fundamental part of daily debit limits and should be included in the messages.

#### What approach has been taken?

A `Date` field will be added to `DailyDebitLimitConsumed` and `DailyDebitLimitExceeded` events.

#### Is there anything you are unsure about?

Nothing.
