### PR TITLE
Use the ubiquitous language for daily debit limit

### DIFF
--- a/messages/events/dailydebitlimit.go
+++ b/messages/events/dailydebitlimit.go
@@ -9,25 +9,25 @@ import (
 // DailyDebitLimitConsumed is an event that indicates an amount of an account
 // daily debit limit has been consumed.
 type DailyDebitLimitConsumed struct {
-	TransactionID string
-	AccountID     string
-	DebitType     messages.TransactionType
-	Amount        int64
-	Date          string
-	LimitConsumed int64
-	LimitMaximum  int64
+	TransactionID     string
+	AccountID         string
+	DebitType         messages.TransactionType
+	Amount            int64
+	Date              string
+	TotalDebitsForDay int64
+	DailyLimit        int64
 }
 
 // DailyDebitLimitExceeded is an event that indicates an attempt to consume from
 // an account daily debit limit has been rejected due to reaching the limit.
 type DailyDebitLimitExceeded struct {
-	TransactionID string
-	AccountID     string
-	DebitType     messages.TransactionType
-	Amount        int64
-	Date          string
-	LimitConsumed int64
-	LimitMaximum  int64
+	TransactionID     string
+	AccountID         string
+	DebitType         messages.TransactionType
+	Amount            int64
+	Date              string
+	TotalDebitsForDay int64
+	DailyLimit        int64
 }
 
 // MessageDescription returns a human-readable description of the message.
@@ -50,6 +50,6 @@ func (m DailyDebitLimitExceeded) MessageDescription() string {
 		m.TransactionID,
 		m.Date,
 		m.AccountID,
-		messages.FormatAmount((m.LimitConsumed+m.Amount)-m.LimitMaximum),
+		messages.FormatAmount((m.TotalDebitsForDay+m.Amount)-m.DailyLimit),
 	)
 }

--- a/messages/events/dailydebitlimit.go
+++ b/messages/events/dailydebitlimit.go
@@ -14,7 +14,7 @@ type DailyDebitLimitConsumed struct {
 	DebitType     messages.TransactionType
 	Amount        int64
 	Date          string
-	LimitUsed     int64
+	LimitConsumed int64
 	LimitMaximum  int64
 }
 
@@ -26,7 +26,7 @@ type DailyDebitLimitExceeded struct {
 	DebitType     messages.TransactionType
 	Amount        int64
 	Date          string
-	LimitUsed     int64
+	LimitConsumed int64
 	LimitMaximum  int64
 }
 
@@ -50,6 +50,6 @@ func (m DailyDebitLimitExceeded) MessageDescription() string {
 		m.TransactionID,
 		m.Date,
 		m.AccountID,
-		messages.FormatAmount((m.LimitUsed+m.Amount)-m.LimitMaximum),
+		messages.FormatAmount((m.LimitConsumed+m.Amount)-m.LimitMaximum),
 	)
 }


### PR DESCRIPTION
#### What change does this introduce?

This PR fixes some of the terminology used in the daily debit limit implementation to match the ubiquitous language.

#### What issues does this relate to?

Fixes #81 

#### Why make this change?

The language used in the domain should match the ubiquitous language as much as possible so that the domain experts and programmers understand each other.

#### Is there anything you are unsure about?

No.
